### PR TITLE
Changing import statement in PipelineExome.py

### DIFF
--- a/CGATPipelines/PipelineExome.py
+++ b/CGATPipelines/PipelineExome.py
@@ -29,8 +29,8 @@ Code
 # Import modules
 import os
 import CGAT.IOTools as IOTools
-import CGAT.Pipeline as P
-from CGAT.Pipeline import cluster_runnable
+import CGATPipelines.Pipeline as P
+from CGATPipelines.Pipeline import cluster_runnable
 import numpy as np
 import pandas as pd
 import CGAT.CSV as csv


### PR DESCRIPTION
Functions in pipeline_exome.py that call functions in PipelineExome.py don't work as import statements in PipelineExome.py are incorrect.  Have changed these so pipeline_exome.py will run ahead of scrum.
