### PR TITLE
fix for #37

### DIFF
--- a/CGATPipelines/pipeline_readqc/pipeline.ini
+++ b/CGATPipelines/pipeline_readqc/pipeline.ini
@@ -177,7 +177,7 @@ no_group=0
 threads=10
 
 # directory for html documentation
-  html=report/html
+html=report/html
 
 # directory for doctrees
 doctrees=report/doctrees


### PR DESCRIPTION
fixed additional spaces inserted into pipeline.ini (causing report_threads parameter to be misread)
