### PR TITLE
Removed picard=1 options to allow portability

### DIFF
--- a/CGATPipelines/PipelineExome.py
+++ b/CGATPipelines/PipelineExome.py
@@ -47,7 +47,7 @@ PARAMS = {}
 
 
 def getGATKOptions():
-    return "-l mem_free=1.4G -l picard=1"
+    return "-l mem_free=1.4G"
 
 
 def makeSoup(address):

--- a/CGATPipelines/PipelineMappingQC.py
+++ b/CGATPipelines/PipelineMappingQC.py
@@ -35,7 +35,7 @@ import CGATPipelines.Pipeline as P
 
 
 def getPicardOptions():
-    return "-l mem_free=1.4G -l picard=1"
+    return "-l mem_free=1.4G"
 
 
 def getNumReadsFromReadsFile(infile):

--- a/CGATPipelines/PipelinePeakcalling.py
+++ b/CGATPipelines/PipelinePeakcalling.py
@@ -356,7 +356,7 @@ def buildBAMforPeakCalling(infiles, outfile, dedup, mask):
         statement.append('''samtools sort @IN@ @OUT@''')
 
     if dedup:
-        job_options = "-l mem_free=16G -l picard=1"
+        job_options = "-l mem_free=16G"
         statement.append('''MarkDuplicates
         INPUT=@IN@
         ASSUME_SORTED=true

--- a/CGATPipelines/pipeline_exome.py
+++ b/CGATPipelines/pipeline_exome.py
@@ -197,7 +197,7 @@ REGEX_FORMATS = regex(r"(\S+).(fastq.1.gz|fastq.gz|sra|csfasta.gz)")
 
 
 def getGATKOptions():
-    return "-l mem_free=1.4G -l picard=1"
+    return "-l mem_free=1.4G"
 
 ###############################################################################
 ###############################################################################


### PR DESCRIPTION
Removing picard resource specification to allow portability. See issue #42 

Might need some testing.
