### PR TITLE
Pipeline_ReadQC Reorganisation 

### DIFF
--- a/CGATPipelines/PipelineMappingQC.py
+++ b/CGATPipelines/PipelineMappingQC.py
@@ -109,7 +109,7 @@ def buildPicardAlignmentStats(infile, outfile, genome_file):
 
     # Picard seems to have problem if quality information is missing
     # or there is no sequence/quality information within the bam file.
-    # Thus, add it explicitely.
+    # Thus, add it explicitly.
     statement = '''cat %(infile)s
     | python %(scriptsdir)s/bam2bam.py -v 0
     --method=set-sequence --output-sam

--- a/CGATPipelines/pipeline_annotations.py
+++ b/CGATPipelines/pipeline_annotations.py
@@ -2122,7 +2122,6 @@ if 0:
         outs.close()
 
 
-
 @transform("*/*.gff.gz",
            suffix(".gff.gz"),
            ".gffsummary.tsv.gz")

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -718,7 +718,8 @@ def mapReadsWithTophat2(infiles, outfile):
         strip_sequence=PARAMS["strip_sequence"])
 
     infile, reffile, transcriptfile = infiles
-    tophat2_options = tophat2_options + " --raw-juncs %(reffile)s " % locals()
+    tophat2_options = PARAMS["tophat2_options"] + \
+        " --raw-juncs %(reffile)s " % locals()
 
     # Nick - added the option to map to the reference transcriptome first
     # (built within the pipeline)

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -1182,6 +1182,9 @@ if "merge_pattern_input" in PARAMS and PARAMS["merge_pattern_input"]:
 
 else:
     @follows(countReads)
+    @transform(SEQUENCEFILES,
+               SEQUENCEFILES_REGEX,
+               r"nreads.dir/\1.nreads")
     def mergeReadCounts():
         pass
 

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -1095,6 +1095,7 @@ def mapReadsWithButter(infile, outfile):
     m = PipelineMapping.Butter(
         strip_sequence=PARAMS["strip_sequence"],
         set_nh=PARAMS["butter_set_nh"])
+
     P.run()
 
 ###################################################################
@@ -1186,6 +1187,8 @@ else:
     @transform(SEQUENCEFILES,
                SEQUENCEFILES_REGEX,
                r"nreads.dir/\1.nreads")
+    # this decorator for the dummy mergeReadCounts is needed to prevent
+    # rerunning of all downstream functions.
     def mergeReadCounts():
         pass
 
@@ -1195,8 +1198,9 @@ else:
 # QC targets
 ###################################################################
 
-############################################################
-########################################################################################################################
+###################################################################
+###################################################################
+###################################################################
 #
 # This is not a pipelined task - remove?
 #
@@ -1284,6 +1288,7 @@ def buildBAMStats(infiles, outfile):
     '''
 
     rna_file = PARAMS["annotations_interface_rna_gff"]
+
     job_memory = "8G"
 
     bamfile, readsfile = infiles

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -278,6 +278,7 @@ def connect():
 
     return dbh
 
+
 @active_if(SPLICED_MAPPING)
 @follows(mkdir("geneset.dir"))
 @merge(PARAMS["annotations_interface_geneset_all_gtf"],

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -1088,15 +1088,10 @@ def mapReadsWithButter(infile, outfile):
         Butter does not support paired end reads''' % locals())
 
     job_threads = PARAMS["butter_threads"]
-<<<<<<< HEAD
-    job_memory = PARAMS["butter_memory"]
-    m = PipelineMapping.Butter(strip_sequence=PARAMS["strip_sequence"])
-=======
     job_options = "-l mem_free=%s" % PARAMS["butter_memory"]
     m = PipelineMapping.Butter(
         strip_sequence=PARAMS["strip_sequence"],
         set_nh=PARAMS["butter_set_nh"])
->>>>>>> 14345e89bfb43ee910097db3c6f94058beafdd2c
     statement = m.build((infile,), outfile)
     P.run()
 
@@ -1313,12 +1308,7 @@ def buildBAMStats(infiles, outfile):
     '''
 
     rna_file = PARAMS["annotations_interface_rna_gff"]
-
-<<<<<<< HEAD
-    job_memory = "12G"
-=======
     job_memory = "1.9G"
->>>>>>> 14345e89bfb43ee910097db3c6f94058beafdd2c
 
     bamfile, readsfile = infiles
 

--- a/CGATPipelines/pipeline_mapping/pipeline.ini
+++ b/CGATPipelines/pipeline_mapping/pipeline.ini
@@ -18,7 +18,7 @@ genome_dir=.
 database=csvdb
 
 # database options for csv2db script
-csv2db_options=--backend=sqlite --retry --map=gene_id:str --map=contig:str --map=transcript_id:str 
+csv2db_options=--retry --map=gene_id:str --map=contig:str --map=transcript_id:str 
 
 # scratchdir for data not to be backed up
 scratchdir=/tmp
@@ -196,6 +196,8 @@ library_type=fr-unstranded
 ################################################################
 ################################################################
 ## hisat options
+## NOTE: 'hangs' frequently - check output directory and cluster
+## status frequently and delete/kill jobs as necessary
 ################################################################
 [hisat]
 #hisat executable.
@@ -248,7 +250,7 @@ memory=0.5G
 
 ################################################################
 ################################################################
-## gsnap options
+## star options
 ################################################################
 [star]
 # star executable. 

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -169,7 +169,6 @@ PROCESSED_INPUT_GLOB = [os.path.join("processed.dir", x)
                         for x in INPUT_FORMATS]
 
 
-
 def connect():
     '''
     Setup a connection to an sqlite database
@@ -370,7 +369,9 @@ def buildFastQCSummaryBasicStatistics(infiles, outfile):
                                                      exportdir)
 
 
-@follows(mkdir("experiment.dir"), mkdir("experiment.dir/processed.dir"), loadFastqc)
+@follows(mkdir("experiment.dir"),
+         mkdir("experiment.dir/processed.dir"),
+         loadFastqc)
 @collate(runFastqc,
          regex("(.*)-([^-]*).fastqc"),
          r"experiment.dir/\1_per_sequence_quality.tsv")

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -177,59 +177,15 @@ def connect():
     dbh = sqlite3.connect(PARAMS['database'])
     return dbh
 
-
-@follows(mkdir(PARAMS["exportdir"]),
-         mkdir(os.path.join(PARAMS["exportdir"], "fastqc")))
-@transform(UNPROCESSED_INPUT_GLOB,
-           REGEX_TRACK,
-           r"\1.fastqc")
-def runFastqc(infiles, outfile):
-    '''run Fastqc on each input file.
-
-    convert sra files to fastq and check mapping qualities are in
-    solexa format.  Perform quality control checks on reads from
-    .fastq files.
-    '''
-    # MM: only pass the contaminants file list if requested by user,
-    # do not make this the default behaviour
-    if PARAMS['add_contaminants']:
-        m = PipelineMapping.FastQc(nogroup=PARAMS["readqc_no_group"],
-                                   outdir=PARAMS["exportdir"] + "/fastqc",
-                                   contaminants=PARAMS['contaminants'])
-    else:
-        m = PipelineMapping.FastQc(nogroup=PARAMS["readqc_no_group"],
-                                   outdir=PARAMS["exportdir"] + "/fastqc")
-
-    statement = m.build((infiles,), outfile)
-    P.run()
-
-
-@jobs_limit(PARAMS.get("jobs_limit_db", 1), "db")
-@transform(runFastqc, suffix(".fastqc"), "_fastqc.load")
-def loadFastqc(infile, outfile):
-    '''load FASTQC stats into database.'''
-    track = P.snip(infile, ".fastqc")
-    filename = os.path.join(
-        PARAMS["exportdir"], "fastqc", track + "*_fastqc", "fastqc_data.txt")
-
-    PipelineReadqc.loadFastqc(filename,
-                              backend=PARAMS["database_backend"],
-                              database=PARAMS["database_name"],
-                              host=PARAMS["database_host"],
-                              username=PARAMS["database_username"],
-                              password=PARAMS["database_password"],
-                              port=PARAMS["database_port"])
-    P.touch(outfile)
-
-# if preprocess tools are specified, process reads and run fastqc on output
+# if preprocess tools are specified, preprocessing is done on output that has
+# already been generated in the first run
 if PARAMS.get("preprocessors", None):
     PREPROCESSTOOLS = [tool for tool
                        in P.asList(PARAMS["preprocessors"])]
     preprocess_prefix = ("-".join(PREPROCESSTOOLS[::-1]) + "-")
 
     if PARAMS["auto_remove"]:
-        @follows(loadFastqc,
-                 mkdir("fasta.dir"))
+        @follows(mkdir("fasta.dir"))
         @transform(INPUT_FORMATS,
                    SEQUENCEFILES_REGEX,
                    r"fasta.dir/\1.fasta")
@@ -257,8 +213,7 @@ if PARAMS.get("preprocessors", None):
             PipelinePreprocess.mergeAdaptorFasta(infiles, outfile)
 
     else:
-        @follows(loadFastqc,
-                 mkdir("fasta.dir"))
+        @follows(mkdir("fasta.dir"))
         @transform(INPUT_FORMATS,
                    SEQUENCEFILES_REGEX,
                    r"fasta.dir/\1.fasta")
@@ -320,39 +275,54 @@ if PARAMS.get("preprocessors", None):
 
         P.run()
 
-    @follows(runFastqc)
-    @transform(processReads,
-               REGEX_TRACK,
-               r"\1.fastqc")
-    def runFastqcFinal(infiles, outfile):
-        '''Perform quality control checks on final processed reads'''
-        m = PipelineMapping.FastQc(nogroup=PARAMS["readqc_no_group"],
-                                   outdir=PARAMS["exportdir"]+"/fastqc")
-        statement = m.build((infiles,), outfile)
-        P.run()
-
-    @jobs_limit(PARAMS.get("jobs_limit_db", 1), "db")
-    @transform(runFastqcFinal, suffix(".fastqc"), "_fastqc.load")
-    def loadFastqcFinal(infile, outfile):
-        '''load FASTQC stats.'''
-        track = P.snip(os.path.basename(infile), ".fastqc")
-        filename = os.path.join(
-            PARAMS["exportdir"], "fastqc",
-            track + "*_fastqc", "fastqc_data.txt")
-        PipelineReadqc.loadFastqc(filename)
-        # P.touch(outfile)
-
 else:
     @follows(mkdir("processed.dir"))
     def processReads():
         pass
 
-    def runFastqcFinal():
-        pass
 
-    def loadFastqcFinal():
-        pass
+@follows(mkdir(PARAMS["exportdir"]),
+         mkdir(os.path.join(PARAMS["exportdir"], "fastqc")))
+@transform(UNPROCESSED_INPUT_GLOB + PROCESSED_INPUT_GLOB,
+           REGEX_TRACK,
+           r"\1.fastqc")
+def runFastqc(infiles, outfile):
+    '''run Fastqc on each input file.
 
+    convert sra files to fastq and check mapping qualities are in
+    solexa format.  Perform quality control checks on reads from
+    .fastq files.
+    '''
+    # MM: only pass the contaminants file list if requested by user,
+    # do not make this the default behaviour
+    if PARAMS['add_contaminants']:
+        m = PipelineMapping.FastQc(nogroup=PARAMS["readqc_no_group"],
+                                   outdir=PARAMS["exportdir"] + "/fastqc",
+                                   contaminants=PARAMS['contaminants'])
+    else:
+        m = PipelineMapping.FastQc(nogroup=PARAMS["readqc_no_group"],
+                                   outdir=PARAMS["exportdir"] + "/fastqc")
+
+    statement = m.build((infiles,), outfile)
+    P.run()
+
+
+@jobs_limit(PARAMS.get("jobs_limit_db", 1), "db")
+@transform(runFastqc, suffix(".fastqc"), "_fastqc.load")
+def loadFastqc(infile, outfile):
+    '''load FASTQC stats into database.'''
+    track = P.snip(infile, ".fastqc")
+    filename = os.path.join(
+        PARAMS["exportdir"], "fastqc", track + "*_fastqc", "fastqc_data.txt")
+
+    PipelineReadqc.loadFastqc(filename,
+                              backend=PARAMS["database_backend"],
+                              database=PARAMS["database_name"],
+                              host=PARAMS["database_host"],
+                              username=PARAMS["database_username"],
+                              password=PARAMS["database_password"],
+                              port=PARAMS["database_port"])
+    P.touch(outfile)
 
 @follows(mkdir(PARAMS["exportdir"]),
          mkdir(os.path.join(PARAMS["exportdir"], "fastq_screen")))
@@ -442,7 +412,6 @@ def loadFastqcSummary(infile, outfile):
 
 @follows(loadFastqc,
          loadFastqcSummary,
-         loadFastqcFinal,
          loadExperimentLevelReadQualities,
          runFastqScreen)
 def full():

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -351,15 +351,15 @@ def runFastqScreen(infiles, outfile):
     shutil.rmtree(tempdir)
 
 
-@merge((runFastqcFinal, runFastqc), "status_summary.tsv.gz")
+@transform(runFastqc, "status_summary.tsv.gz")
 def buildFastQCSummaryStatus(infiles, outfile):
     '''load fastqc status summaries into a single table.'''
     exportdir = os.path.join(PARAMS["exportdir"], "fastqc")
     PipelineReadqc.buildFastQCSummaryStatus(infiles, outfile, exportdir)
 
 
-@follows(loadFastqcFinal, loadFastqc)
-@merge((runFastqcFinal, runFastqc), "basic_statistics_summary.tsv.gz")
+@follows(loadFastqc)
+@transform(runFastqc, "basic_statistics_summary.tsv.gz")
 def buildFastQCSummaryBasicStatistics(infiles, outfile):
     '''load fastqc summaries into a single table.'''
     exportdir = os.path.join(PARAMS["exportdir"], "fastqc")

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -217,13 +217,12 @@ if PARAMS.get("preprocessors", None):
             PipelinePreprocess.mergeAdaptorFasta(infiles, outfile)
 
     else:
-
         @follows(mkdir("fasta.dir"))
         @transform(INPUT_FORMATS,
                    SEQUENCEFILES_REGEX,
                    r"fasta.dir/\1.fasta")
         def aggregateAdaptors(infile, outfile):
-            print("I'm there\n")
+
             P.touch(outfile)
 
     @follows(mkdir("processed.dir"),

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -373,9 +373,7 @@ def buildFastQCSummaryBasicStatistics(infiles, outfile):
                                                      exportdir)
 
 
-@follows(mkdir("experiment.dir"),
-         mkdir("experiment.dir/processed.dir"),
-         loadFastqc)
+@follows(mkdir("experiment.dir"), loadFastqc)
 @collate(runFastqc,
          regex("(processed.dir/)*(.*)-([^-]*).fastqc"),
          r"experiment.dir/\2_per_sequence_quality.tsv")

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -158,6 +158,10 @@ INPUT_FORMATS = ["*.fastq.1.gz", "*.fastq.gz", "*.sra", "*.csfasta.gz"]
 # a directory as part of the track.
 REGEX_TRACK = regex(r"([^/]+).(fastq.1.gz|fastq.gz|sra|csfasta.gz)")
 
+# Regular expression to extract a track from both processed and unprocessed
+# files
+REGEX_TRACK_BOTH = regex(r"(processed.dir/)*([^/]+)\.(fastq.1.gz|fastq.gz|sra|csfasta.gz)")
+
 SEQUENCEFILES_REGEX = regex(
     r"(\S+).(?P<suffix>fastq.1.gz|fastq.gz|sra|csfasta.gz)")
 
@@ -329,8 +333,8 @@ def loadFastqc(infile, outfile):
 @follows(mkdir(PARAMS["exportdir"]),
          mkdir(os.path.join(PARAMS["exportdir"], "fastq_screen")))
 @transform(UNPROCESSED_INPUT_GLOB + PROCESSED_INPUT_GLOB,
-           REGEX_TRACK,
-           r"%s/fastq_screen/\1.fastq.1_screen.png" % PARAMS['exportdir'])
+           REGEX_TRACK_BOTH,
+           r"%s/fastq_screen/\2.fastq.1_screen.png" % PARAMS['exportdir'])
 def runFastqScreen(infiles, outfile):
     '''run FastqScreen on input files.'''
 
@@ -373,8 +377,8 @@ def buildFastQCSummaryBasicStatistics(infiles, outfile):
          mkdir("experiment.dir/processed.dir"),
          loadFastqc)
 @collate(runFastqc,
-         regex("(.*)-([^-]*).fastqc"),
-         r"experiment.dir/\1_per_sequence_quality.tsv")
+         regex("(processed.dir/)*(.*)-([^-]*).fastqc"),
+         r"experiment.dir/\2_per_sequence_quality.tsv")
 def buildExperimentLevelReadQuality(infiles, outfile):
     """
     Collate per sequence read qualities for all replicates per experiment.

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -157,6 +157,7 @@ INPUT_FORMATS = ["*.fastq.1.gz", "*.fastq.gz", "*.sra", "*.csfasta.gz"]
 # Regular expression to extract a track from an input file. Does not preserve
 # a directory as part of the track.
 REGEX_TRACK = regex(r"([^/]+).(fastq.1.gz|fastq.gz|sra|csfasta.gz)")
+REGEX_FASTQC = regex(r"([^/]+).fastqc")
 
 SEQUENCEFILES_REGEX = regex(
     r"(\S+).(?P<suffix>fastq.1.gz|fastq.gz|sra|csfasta.gz)")
@@ -351,7 +352,7 @@ def runFastqScreen(infiles, outfile):
     shutil.rmtree(tempdir)
 
 
-@transform(runFastqc, "status_summary.tsv.gz")
+@transform(runFastqc, suffix(".fastqc"), "status_summary.tsv.gz")
 def buildFastQCSummaryStatus(infiles, outfile):
     '''load fastqc status summaries into a single table.'''
     exportdir = os.path.join(PARAMS["exportdir"], "fastqc")
@@ -359,7 +360,7 @@ def buildFastQCSummaryStatus(infiles, outfile):
 
 
 @follows(loadFastqc)
-@transform(runFastqc, "basic_statistics_summary.tsv.gz")
+@transform(runFastqc, suffix(".fastqc"), "basic_statistics_summary.tsv.gz")
 def buildFastQCSummaryBasicStatistics(infiles, outfile):
     '''load fastqc summaries into a single table.'''
     exportdir = os.path.join(PARAMS["exportdir"], "fastqc")

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -416,8 +416,7 @@ def loadFastqcSummary(infile, outfile):
     P.load(infile, outfile, options="--add-index=track")
 
 
-@follows(processReads,
-         loadFastqc,
+@follows(loadFastqc,
          loadFastqcSummary,
          loadExperimentLevelReadQualities,
          runFastqScreen)

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -325,6 +325,7 @@ def loadFastqc(infile, outfile):
                               port=PARAMS["database_port"])
     P.touch(outfile)
 
+
 @follows(mkdir(PARAMS["exportdir"]),
          mkdir(os.path.join(PARAMS["exportdir"], "fastq_screen")))
 @transform(UNPROCESSED_INPUT_GLOB + PROCESSED_INPUT_GLOB,

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -157,7 +157,6 @@ INPUT_FORMATS = ["*.fastq.1.gz", "*.fastq.gz", "*.sra", "*.csfasta.gz"]
 # Regular expression to extract a track from an input file. Does not preserve
 # a directory as part of the track.
 REGEX_TRACK = regex(r"([^/]+).(fastq.1.gz|fastq.gz|sra|csfasta.gz)")
-REGEX_FASTQC = regex(r"([^/]+).fastqc")
 
 SEQUENCEFILES_REGEX = regex(
     r"(\S+).(?P<suffix>fastq.1.gz|fastq.gz|sra|csfasta.gz)")
@@ -168,6 +167,7 @@ UNPROCESSED_INPUT_GLOB = INPUT_FORMATS
 # List of processed (trimmed, etc) input files
 PROCESSED_INPUT_GLOB = [os.path.join("processed.dir", x)
                         for x in INPUT_FORMATS]
+
 
 
 def connect():
@@ -370,7 +370,7 @@ def buildFastQCSummaryBasicStatistics(infiles, outfile):
                                                      exportdir)
 
 
-@follows(mkdir("experiment.dir"))
+@follows(mkdir("experiment.dir"), mkdir("experiment.dir/processed.dir"), loadFastqc)
 @collate(runFastqc,
          regex("(.*)-([^-]*).fastqc"),
          r"experiment.dir/\1_per_sequence_quality.tsv")

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -184,13 +184,13 @@ if PARAMS.get("preprocessors", None):
     PREPROCESSTOOLS = [tool for tool
                        in P.asList(PARAMS["preprocessors"])]
     preprocess_prefix = ("-".join(PREPROCESSTOOLS[::-1]) + "-")
-
     if PARAMS["auto_remove"]:
         @follows(mkdir("fasta.dir"))
         @transform(INPUT_FORMATS,
                    SEQUENCEFILES_REGEX,
                    r"fasta.dir/\1.fasta")
         def makeAdaptorFasta(infile, outfile):
+
             '''
             Make a single fasta file for each sample of all contaminant adaptor
             sequences for removal
@@ -214,12 +214,13 @@ if PARAMS.get("preprocessors", None):
             PipelinePreprocess.mergeAdaptorFasta(infiles, outfile)
 
     else:
+
         @follows(mkdir("fasta.dir"))
         @transform(INPUT_FORMATS,
                    SEQUENCEFILES_REGEX,
                    r"fasta.dir/\1.fasta")
         def aggregateAdaptors(infile, outfile):
-
+            print("I'm there\n")
             P.touch(outfile)
 
     @follows(mkdir("processed.dir"),
@@ -282,7 +283,7 @@ else:
         pass
 
 
-@follows(mkdir(PARAMS["exportdir"]),
+@follows(processReads, mkdir(PARAMS["exportdir"]),
          mkdir(os.path.join(PARAMS["exportdir"], "fastqc")))
 @transform(UNPROCESSED_INPUT_GLOB + PROCESSED_INPUT_GLOB,
            REGEX_TRACK,
@@ -330,7 +331,7 @@ def loadFastqc(infile, outfile):
          mkdir(os.path.join(PARAMS["exportdir"], "fastq_screen")))
 @transform(UNPROCESSED_INPUT_GLOB + PROCESSED_INPUT_GLOB,
            REGEX_TRACK,
-            r"%s/fastq_screen/\1.fastq.1_screen.png" % PARAMS['exportdir'])
+           r"%s/fastq_screen/\1.fastq.1_screen.png" % PARAMS['exportdir'])
 def runFastqScreen(infiles, outfile):
     '''run FastqScreen on input files.'''
 
@@ -412,7 +413,8 @@ def loadFastqcSummary(infile, outfile):
     P.load(infile, outfile, options="--add-index=track")
 
 
-@follows(loadFastqc,
+@follows(processReads,
+         loadFastqc,
          loadFastqcSummary,
          loadExperimentLevelReadQualities,
          runFastqScreen)

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -330,7 +330,7 @@ def loadFastqc(infile, outfile):
          mkdir(os.path.join(PARAMS["exportdir"], "fastq_screen")))
 @transform(UNPROCESSED_INPUT_GLOB + PROCESSED_INPUT_GLOB,
            REGEX_TRACK,
-           r"\1.fastqscreen")
+            r"%s/fastq_screen/\1.fastq.1_screen.png" % PARAMS['exportdir'])
 def runFastqScreen(infiles, outfile):
     '''run FastqScreen on input files.'''
 
@@ -353,7 +353,7 @@ def runFastqScreen(infiles, outfile):
     shutil.rmtree(tempdir)
 
 
-@transform(runFastqc, suffix(".fastqc"), "status_summary.tsv.gz")
+@merge(runFastqc, "status_summary.tsv.gz")
 def buildFastQCSummaryStatus(infiles, outfile):
     '''load fastqc status summaries into a single table.'''
     exportdir = os.path.join(PARAMS["exportdir"], "fastqc")
@@ -361,7 +361,7 @@ def buildFastQCSummaryStatus(infiles, outfile):
 
 
 @follows(loadFastqc)
-@transform(runFastqc, suffix(".fastqc"), "basic_statistics_summary.tsv.gz")
+@merge(runFastqc, "basic_statistics_summary.tsv.gz")
 def buildFastQCSummaryBasicStatistics(infiles, outfile):
     '''load fastqc summaries into a single table.'''
     exportdir = os.path.join(PARAMS["exportdir"], "fastqc")

--- a/CGATPipelines/pipeline_readqc/pipeline.ini
+++ b/CGATPipelines/pipeline_readqc/pipeline.ini
@@ -6,8 +6,37 @@ exportdir=export
 # directory for publishing results on the web
 web_dir=../../web
 
+
+################################################################
+################################################################
+##### fastq_screen options
+################################################################
+[fastq_screen]
+# --threads
+# --subset: subset of genome to be analysed
+options=--threads 10 --subset 100000
+################################################################
+# fastq_screeen DATABASES
+# fastq_screen requires paths to bowtie indices for all 
+# contaminants. Put a '#' in front of organisms you are not
+# interested in or add other ones using the same format
+# database prefix is mandatory!
+database_human=/ifs/mirror/genomes/bowtie/hg19
+database_mouse=/ifs/mirror/genomes/bowtie/mm9
+database_rat=/ifs/mirror/genomes/bowtie/rn5
+database_yeast=/ifs/mirror/genomes/bowtie/sacCer3
+database_phix=/ifs/mirror/genomes/bowtie/phix
+database_bacteria1of2=/ifs/mirror/genomes/bowtie/ncbi_prokaryotes_1of2
+database_bacteria2of2=/ifs/mirror/genomes/bowtie/ncbi_prokaryotes_2of2
+database_contaminants=/ifs/mirror/genomes/bowtie/contaminant_list
+
+
+################################################################
 ################################################################
 # preprocessing options
+################################################################
+# these options will only work if you have run the 
+# readqc_pipeline previously
   
 # specify a comma seperated list of preprocessing tools to run
 # current options are:
@@ -15,7 +44,7 @@ web_dir=../../web
 # trimgalore
 # fastx_trimmer
 # sickle
-# flash  
+# flash
 preprocessors=
 
 # set to 1 to keep all intermediate files
@@ -139,30 +168,6 @@ options=-m 15 -M 50 -r 50 -f 300
 # -q quality threshold
 # if auto_remove is set then make sure there are no -a flags here
 options=-a AGATCGGAAGAGC --overlap 18 --minimum-length 25 --maximum-length 28 -q 20
-
-################################################################
-################################################################
-##### fastq_screen options
-##### will only be run if any preprocessing is selected
-################################################################
-[fastq_screen]
-# --threads
-# --subset: subset of genome to be analysed
-options=--threads 10 --subset 100000
-################################################################
-# fastq_screeen DATABASES
-# fastq_screen requires paths to bowtie indices for all 
-# contaminants. Put a '#' in front of organisms you are not
-# interested in or add other ones using the same format
-# database prefix is mandatory!
-database_human=/ifs/mirror/genomes/bowtie/hg19
-database_mouse=/ifs/mirror/genomes/bowtie/mm9
-database_rat=/ifs/mirror/genomes/bowtie/rn5
-database_yeast=/ifs/mirror/genomes/bowtie/sacCer3
-database_phix=/ifs/mirror/genomes/bowtie/phix
-database_bacteria1of2=/ifs/mirror/genomes/bowtie/ncbi_prokaryotes_1of2
-database_bacteria2of2=/ifs/mirror/genomes/bowtie/ncbi_prokaryotes_2of2
-database_contaminants=/ifs/mirror/genomes/bowtie/contaminant_list
 
 
 ################################################################


### PR DESCRIPTION
Changes:
1. Removes function duplication in pipeline_readqc - Issue #36
2. FastQScreen is now run by default for all runs & skipped if output present
3. Per_experiment_per_sequence_quality is now run on the processed output also

Also: fixed decorator in pipeline_mapping that was causing rerunning of one arm of pipeline
