### PR TITLE
removed (my) bug in cluster_runnable decorator

### DIFF
--- a/CGATPipelines/Pipeline.py
+++ b/CGATPipelines/Pipeline.py
@@ -1679,7 +1679,7 @@ def submit(module, function, params=None,
            logfile=None,
            job_options="",
            job_threads=1,
-           job_memory=""):
+           job_memory=False):
     '''submit a python *function* as a job to the cluster.
 
     The function should reside in *module*. If *module* is
@@ -1689,6 +1689,9 @@ def submit(module, function, params=None,
     input/output filenames. Neither options supports yet nested lists.
 
     '''
+
+    if not job_memory:
+        job_memory = PARAMS.get("cluster_memory_default", "2G")
 
     if type(infiles) in (list, tuple):
         infiles = " ".join(["--input=%s" % x for x in infiles])

--- a/CGATPipelines/PipelineMappingQC.py
+++ b/CGATPipelines/PipelineMappingQC.py
@@ -457,6 +457,8 @@ def loadBAMStats(infiles, outfile):
         E.info("loading bam stats - %s" % suffix)
         filenames = " ".join(["%s.%s" % (x, suffix) for x in infiles])
         
+        tablename = "%s_%s" % (P.toTable(outfile), suffix)
+
         load_statement = P.build_load_statement(
             "%s_%s" % (tablename, suffix),
             options=" --allow-empty-file")

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -1284,7 +1284,7 @@ def buildBAMStats(infiles, outfile):
 
     rna_file = PARAMS["annotations_interface_rna_gff"]
 
-    job_memory = "8G"
+    job_memory = "16G"
 
     bamfile, readsfile = infiles
 


### PR DESCRIPTION
A accidentally added a bug to the cluster_runnable decorator so that any job which didn't specify the job_memory would throw an error. This branch resolves the bug.
