### PR TITLE
RNA-Seq Differential Expression Pipeline Changes

### DIFF
--- a/CGATPipelines/Pipeline.py
+++ b/CGATPipelines/Pipeline.py
@@ -1495,7 +1495,7 @@ def run(**kwargs):
         # such as v_hmem.
         # Note that limiting resident set sizes (RSS) with ulimit is not
         # possible in newer kernels.
-        tmpfile.write("ulimit -v %i\n" % IOTools.human2bytes(job_memory))
+        #tmpfile.write("ulimit -v %i\n" % IOTools.human2bytes(job_memory))
 
         tmpfile.write(
             expandStatement(

--- a/CGATPipelines/Pipeline.py
+++ b/CGATPipelines/Pipeline.py
@@ -864,7 +864,6 @@ def concatenateAndLoad(infiles,
     statement = '''python %(scriptsdir)s/combine_tables.py
     --cat=%(cat)s
     --missing-value=%(missing_value)s
-    %(no_titles)s
     %(cat_options)s
     %(infiles)s
     | %(load_statement)s

--- a/CGATPipelines/PipelineRnaseq.py
+++ b/CGATPipelines/PipelineRnaseq.py
@@ -1062,7 +1062,7 @@ def loadCuffdiff(infile, outfile, min_fpkm=1.0):
                "--add-index=treatment_name "
                "--add-index=control_name "
                "--add-index=test_id")
-               
+
     for fn, level in (("cds.fpkm_tracking.gz", "cds"),
                       ("genes.fpkm_tracking.gz", "gene"),
                       ("isoforms.fpkm_tracking.gz", "isoform"),
@@ -1255,7 +1255,7 @@ def runCuffdiff(bamfiles,
     # Error is:
     # BAM record error: found spliced alignment without XS attribute
     # AH: compress output in outdir
-    job_memory="24G"
+    job_memory = "7G"
     statement = '''date > %(outfile)s.log;
     hostname >> %(outfile)s.log;
     cuffdiff --output-dir %(outdir)s

--- a/CGATPipelines/PipelineRnaseq.py
+++ b/CGATPipelines/PipelineRnaseq.py
@@ -836,6 +836,7 @@ def buildExpressionStats(dbhandle, tables, genesets, method, outfile, outdir):
 
     <exportdir>/<method> directory.
     '''
+
     def _genesetintablename(table, genesets):
         out = []
         for g in genesets:
@@ -900,7 +901,6 @@ def buildExpressionStats(dbhandle, tables, genesets, method, outfile, outdir):
                 return collections.defaultdict(
                     int,
                     [(tuple(x[:l]), x[l]) for x in vals])
-            
 
             tested = toDict(
                 Database.executewait(

--- a/CGATPipelines/PipelineRnaseq.py
+++ b/CGATPipelines/PipelineRnaseq.py
@@ -743,8 +743,8 @@ def mergeCufflinksFPKM(infiles, outfile,
     fpkm_tracking: isoforms
     '''
 
-    prefix = os.path.basename(outfile)
-    prefix = prefix[:prefix.index("_")]
+    prefix = os.path.basename(infiles[0])
+    prefix = prefix[:prefix.rfind("_")]
     print prefix
 
     headers = ",".join(

--- a/CGATPipelines/PipelineRnaseq.py
+++ b/CGATPipelines/PipelineRnaseq.py
@@ -1255,6 +1255,7 @@ def runCuffdiff(bamfiles,
     # Error is:
     # BAM record error: found spliced alignment without XS attribute
     # AH: compress output in outdir
+    job_memory="24G"
     statement = '''date > %(outfile)s.log;
     hostname >> %(outfile)s.log;
     cuffdiff --output-dir %(outdir)s

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -261,7 +261,7 @@ if PARAMS.get("preprocessors", None):
             trimmomatic_options = adapter_options + trimmomatic_options
 
         job_threads = PARAMS["threads"]
-        job_memory = "24G"
+        job_memory = "7G"
 
         m = PipelinePreprocess.MasterProcessor(
             save=PARAMS["save"],

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -261,7 +261,7 @@ if PARAMS.get("preprocessors", None):
             trimmomatic_options = adapter_options + trimmomatic_options
 
         job_threads = PARAMS["threads"]
-        job_options = "-l mem_free=%s" % PARAMS["general_memory"]
+        job_memory = "24G"
 
         m = PipelinePreprocess.MasterProcessor(
             save=PARAMS["save"],

--- a/CGATPipelines/pipeline_rnaseqdiffexpression.py
+++ b/CGATPipelines/pipeline_rnaseqdiffexpression.py
@@ -620,7 +620,7 @@ def buildCuffdiffStats(infiles, outfile):
     outdir = os.path.dirname(infiles[0])
     PipelineRnaseq.buildExpressionStats(
         connect(),
-        tablenames, "cuffdiff", outfile, outdir)
+        tablenames, GENESETS, "cuffdiff", outfile, outdir)
 
 #########################################################################
 #########################################################################
@@ -1078,7 +1078,7 @@ def buildDESeqStats(infiles, outfile):
     outdir = os.path.dirname(infiles[0])
     PipelineRnaseq.buildExpressionStats(
         connect(),
-        tablenames, "deseq", outfile, outdir)
+        tablenames, GENESETS, "deseq", outfile, outdir)
 
 
 @transform(buildDESeqStats,
@@ -1131,10 +1131,11 @@ def loadEdgeR(infile, outfile):
 @merge(loadEdgeR, "edger_stats.tsv")
 def buildEdgeRStats(infiles, outfile):
     tablenames = [P.toTable(x) for x in infiles]
+    print tablenames
     outdir = os.path.dirname(infiles[0])
     PipelineRnaseq.buildExpressionStats(
         connect(),
-        tablenames, "edger", outfile, outdir)
+        tablenames, GENESETS, "edger", outfile, outdir)
 
 
 @transform(buildEdgeRStats,

--- a/CGATPipelines/pipeline_rnaseqdiffexpression.py
+++ b/CGATPipelines/pipeline_rnaseqdiffexpression.py
@@ -1021,6 +1021,9 @@ def loadTagCountSummary(infile, outfile):
          loadFeatureCountsSummary,
          aggregateGeneLevelReadCounts,
          aggregateFeatureCounts)
+@transform((summarizeCounts,
+            summarizeCountsPerDesign),
+           suffix("_stats.tsv"), "_stats.load")
 def counting():
     pass
 

--- a/CGATPipelines/pipeline_rnaseqdiffexpression.py
+++ b/CGATPipelines/pipeline_rnaseqdiffexpression.py
@@ -425,7 +425,7 @@ def runCufflinks(infiles, outfile):
 
 
 @transform(runCufflinks,
-          suffix(".cufflinks"),
+           suffix(".cufflinks"),
            ".load")
 def loadCufflinks(infile, outfile):
     '''load expression level measurements.'''

--- a/CGATPipelines/pipeline_rnaseqdiffexpression.py
+++ b/CGATPipelines/pipeline_rnaseqdiffexpression.py
@@ -23,7 +23,6 @@ The pipeline performs the following:
 
    * compute tag counts on an exon, transcript and gene level for each
      of the genesets. The following tag counting methods are implemented:
-
       * featureCounts_
       * gtf2table
 
@@ -115,7 +114,9 @@ Design matrices
 
 Design matrices are imported by placing :term:`tsv` formatted files
 into the :term:`working directory`. A design matrix describes the
-experimental design to test. Each design file has four columns::
+experimental design to test. The design files should be named
+design*.tsv.
+Each design file has four columns::
 
       track   include group   pair
       CW-CD14-R1      0       CD14    1
@@ -405,7 +406,7 @@ def runCufflinks(infiles, outfile):
 
 
 @transform(runCufflinks,
-           suffix(".cufflinks"),
+          suffix(".cufflinks"),
            ".load")
 def loadCufflinks(infile, outfile):
     '''load expression level measurements.'''

--- a/CGATPipelines/pipeline_rnaseqdiffexpression.py
+++ b/CGATPipelines/pipeline_rnaseqdiffexpression.py
@@ -146,7 +146,7 @@ Requirements
 
 The pipeline requires the results from
 :doc:`pipeline_annotations`. Set the configuration variable
-:py:data:`annotations_database` and :py:data:`annotations_dir`.
+:py:data:`annotations_annotations_database` and :py:data:`annotations_dir`.
 
 On top of the default CGAT setup, the pipeline requires the following
 software to be in the path:
@@ -378,8 +378,6 @@ def buildMaskGtf(infile, outfile):
     dbh = connect()
     table = os.path.basename(PARAMS["annotations_interface_table_gene_info"])
     table2 = os.path.basename(PARAMS["annotations_interface_table_gene_stats"])
-    print table
-    print table2
 
     try:
         select = dbh.execute("""SELECT DISTINCT gene_id FROM %(table)s
@@ -396,7 +394,6 @@ def buildMaskGtf(infile, outfile):
         E.critical("sqlite3 cannot find table or contig column. "
                    "Error message: '%s'" % error)
     chrM_list = [x[0] for x in select2]
-    print type(chrM_list)
 
     geneset = IOTools.openFile(infile)
     outf = open(outfile, "wb")

--- a/CGATPipelines/pipeline_rnaseqdiffexpression/pipeline.ini
+++ b/CGATPipelines/pipeline_rnaseqdiffexpression/pipeline.ini
@@ -36,7 +36,7 @@ methods=cuffdiff,deseq,edger
 ## Location of annotation database
 ################################################################
 [annotations]
-database=/ifs/data/annotations/hg19_ensembl62/csvdb
+annotations_database=/ifs/data/annotations/hg19_ensembl62/csvdb
 
 # directory with annotation information
 dir=


### PR DESCRIPTION
Changes include:
- bugfix in Pipeline.py
- in Pipelinernaseq.py (thanks @MikeDMorgan )
  - new function _genesetintablename that now correctly extracts the
    geneset name from the table name (previously all genesets were
    merged into one)
  - new code that corrects/aligns the cuffdiff output with
    deseq/edger and allows for creation of summary tables
- in Pipeline_Rnaseqdiffexpression.py (thanks @TomSmithCGAT )
  - new code that now correctly creates a new gtf_mask file
    (previous failed due to changes in new ensembl annotations files)
  - resolved duplication of annotations_database parameter 
- memory requirement for processreads(readqc pipeline) and cuffdiff (rnaseq pipeline) changed to job_memory and set to 7G
