### PR TITLE
SRA/CSFasta support for PipelineReadQC & Preprocessing (#35)

### DIFF
--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -545,7 +545,6 @@ class Mapper(object):
                             ("%s/%s" % (tmpdir_fastq, basename),))
                     elif len(sra_extraction_files) == 2:
                         infile2 = sra_extraction_files[1]
-                        print basename
                         if basename.endswith("_1.fastq.gz"):
                             basename1 = basename[:-11] + ".fastq.1.gz"
                             basename2 = basename[:-11] + ".fastq.2.gz"
@@ -683,8 +682,6 @@ class Mapper(object):
         self.tmpdir_fastq = tmpdir_fastq
 
         assert len(fastqfiles) > 0, "no fastq files for mapping"
-        print "; ".join(statement) + ";"
-        print fastqfiles
         return "; ".join(statement) + ";", fastqfiles
 
     def mapper(self, infiles, outfile):
@@ -840,8 +837,6 @@ class FastqScreen(Mapper):
             infile1, infile2 = infiles[0]
             input_files = '''-- paired %(infile1)s %(infile2)s''' % locals()
         else:
-            print nfiles
-            print infiles
             raise ValueError(
                 "unexpected number read files to map: %i " % nfiles)
 
@@ -890,7 +885,6 @@ class Sailfish(Mapper):
             library.append(strandedness)
 
         elif nfiles == 2:
-            print "infiles: ", infiles
             infile1, infile2 = infiles[0]
             input_file = '''-1 <(zcat %(infile1)s)
                             -2 <(zcat %(infile2)s)''' % locals()

--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -530,7 +530,7 @@ class Mapper(object):
                              "%s/%s_converted.2.fastq%s" %
                              (tmpdir_fastq, track, extension)))
                 else:
-                    # Usually sra extraction files have output format
+                    # Usually sra extraction files have format
                     # '1_fastq.gz' for both single and paired end files
                     # This code corrects the output to the format expected by
                     # CGAT Pipelines
@@ -547,8 +547,8 @@ class Mapper(object):
                         infile2 = sra_extraction_files[1]
                         print basename
                         if basename.endswith("_1.fastq.gz"):
-                            basename1 = basename[:-11] + ".1.fastq.gz"
-                            basename2 = basename[:-11] + ".2.fastq.gz"
+                            basename1 = basename[:-11] + ".fastq.1.gz"
+                            basename2 = basename[:-11] + ".fastq.2.gz"
                         statement.append(
                             "mv %s %s/%s; mv %s %s/%s" %
                             (infile, tmpdir_fastq, basename1,

--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -489,6 +489,8 @@ class Mapper(object):
 
                         infile = sra_extraction_files[0]
                         track = os.path.splitext(os.path.basename(infile))[0]
+                        if track.endswith("_1"):
+                            track = track[:-2]
 
                         statement.append("""gunzip < %(infile)s
                         | python %%(scriptsdir)s/fastq2fastq.py

--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -670,7 +670,6 @@ class Mapper(object):
     def cleanup(self, outfile):
         '''clean up.'''
         statement = '''rm -rf %s;''' % (self.tmpdir_fastq)
-        # statement = ""
 
         return statement
 

--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -489,9 +489,8 @@ class Mapper(object):
 
                         infile = sra_extraction_files[0]
                         track = os.path.splitext(os.path.basename(infile))[0]
-                        if track.endswith("_1"):
-                            track = track[:-2]
-
+                        if track.endswith("_1.fastq"):
+                            track = track[:-8]
                         statement.append("""gunzip < %(infile)s
                         | python %%(scriptsdir)s/fastq2fastq.py
                         --method=change-format --target-format=sanger
@@ -531,7 +530,34 @@ class Mapper(object):
                              "%s/%s_converted.2.fastq%s" %
                              (tmpdir_fastq, track, extension)))
                 else:
-                    fastqfiles.append(sra_extraction_files)
+                    # Usually sra extraction files have output format
+                    # '1_fastq.gz' for both single and paired end files
+                    # This code corrects the output to the format expected by
+                    # CGAT Pipelines
+                    infile = sra_extraction_files[0]
+                    basename = os.path.basename(infile)
+                    if (len(sra_extraction_files) == 1
+                            and basename.endswith("_1.fastq.gz")):
+                        basename = basename[:-11] + ".fastq.gz"
+                        statement.append(
+                            "mv %s %s/%s" % (infile, tmpdir_fastq, basename))
+                        fastqfiles.append(
+                            ("%s/%s" % (tmpdir_fastq, basename),))
+                    elif len(sra_extraction_files) == 2:
+                        infile2 = sra_extraction_files[1]
+                        print basename
+                        if basename.endswith("_1.fastq.gz"):
+                            basename1 = basename[:-11] + ".1.fastq.gz"
+                            basename2 = basename[:-11] + ".2.fastq.gz"
+                        statement.append(
+                            "mv %s %s/%s; mv %s %s/%s" %
+                            (infile, tmpdir_fastq, basename1,
+                             infile2, tmpdir_fastq, basename2))
+                        fastqfiles.append(
+                            ("%s/%s" % (tmpdir_fastq, basename1),
+                             "%s/%s" % (tmpdir_fastq, basename2)))
+                    else:
+                        fastqfiles.append(sra_extraction_files)
 
             elif infile.endswith(".fastq.gz"):
                 format = Fastq.guessFormat(
@@ -657,7 +683,8 @@ class Mapper(object):
         self.tmpdir_fastq = tmpdir_fastq
 
         assert len(fastqfiles) > 0, "no fastq files for mapping"
-
+        print "; ".join(statement) + ";"
+        print fastqfiles
         return "; ".join(statement) + ";", fastqfiles
 
     def mapper(self, infiles, outfile):
@@ -813,6 +840,8 @@ class FastqScreen(Mapper):
             infile1, infile2 = infiles[0]
             input_files = '''-- paired %(infile1)s %(infile2)s''' % locals()
         else:
+            print nfiles
+            print infiles
             raise ValueError(
                 "unexpected number read files to map: %i " % nfiles)
 

--- a/CGATPipelines/PipelinePreprocess.py
+++ b/CGATPipelines/PipelinePreprocess.py
@@ -241,13 +241,11 @@ def getSequencingInformation(track):
                                       colour))
 
 
-class MasterProcessor():
+class MasterProcessor(Mapping.Mapper):
 
     '''Processes reads with tools specified.
     All in a single statement to be send to the cluster.
     '''
-
-    datatype = "fastq"
 
     # compress temporary fastq files with gzip
     compress = False
@@ -294,7 +292,7 @@ class MasterProcessor():
             return filename
 
     def process(self, infile, list_of_preprocessers, outfile,
-                f_format, compress=False, save=True):
+                compress=False, save=True):
         '''build processing statement on infiles.  list of processing
         tools is used to build a command line statement in list order'''
 
@@ -327,57 +325,57 @@ class MasterProcessor():
             if tool == "fastx_trimmer":
                 fastx_trimmer_object = fastx_trimmer(
                     compress=file_compress, save=save_intermediates,
-                    final=end, f_format=f_format, num_files=num_files,
+                    final=end, num_files=num_files,
                     first=first, outdir=self.outdir,
                     prefix="fastx_trimmer-", summarise=self.summarise,
                     options=self.fastx_trimmer_opt, threads=self.threads)
-                tool_cmd, post_cmd, infiles, f_format, num_files = (
+                tool_cmd, post_cmd, infiles, num_files = (
                     fastx_trimmer_object.build(infiles))
             elif tool == "trimmomatic":
                 trimmomatic_object = trimmomatic(
                     compress=file_compress, save=save_intermediates,
-                    final=end, f_format=f_format, num_files=num_files,
+                    final=end, num_files=num_files,
                     first=first, outdir=self.outdir,
                     prefix="trimmomatic-", summarise=self.summarise,
                     options=self.trimmomatic_opt, threads=self.threads)
-                tool_cmd, post_cmd, infiles, f_format, num_files = (
+                tool_cmd, post_cmd, infiles, num_files = (
                     trimmomatic_object.build(infiles))
             elif tool == "sickle":
                 sickle_object = sickle(
                     compress=file_compress, save=save_intermediates,
-                    final=end, f_format=f_format, num_files=num_files,
+                    final=end, num_files=num_files,
                     first=first, outdir=self.outdir,
                     prefix="sickle-", summarise=self.summarise,
                     options=self.sickle_opt, threads=self.threads)
-                tool_cmd, post_cmd, infiles,  f_format, num_files = (
+                tool_cmd, post_cmd, infiles, num_files = (
                     sickle_object.build(infiles))
             elif tool == "trimgalore":
                 trimgalore_object = trimgalore(
                     compress=file_compress, save=save_intermediates,
-                    final=end, f_format=f_format, num_files=num_files,
+                    final=end, num_files=num_files,
                     first=first, outdir=self.outdir,
                     prefix="trimgalore-", summarise=self.summarise,
                     options=self.trimgalore_opt, threads=self.threads)
-                tool_cmd, post_cmd, infiles, f_format, num_files = (
+                tool_cmd, post_cmd, infiles, num_files = (
                     trimgalore_object.build(infiles))
             elif tool == "flash":
                 flash_object = flash(
                     compress=file_compress, save=save_intermediates,
-                    final=end, f_format=f_format, num_files=num_files,
+                    final=end, num_files=num_files,
                     first=first, outdir=self.outdir,
                     prefix="flash-", summarise=self.summarise,
                     options=self.flash_opt, threads=self.threads)
-                tool_cmd, post_cmd, infiles, f_format, num_files = (
+                tool_cmd, post_cmd, infiles, num_files = (
                     flash_object.build(infiles))
             elif tool == "cutadapt":
                 cutadapt_object = cutadapt(
                     compress=file_compress, save=save_intermediates,
-                    final=end, f_format=f_format, num_files=num_files,
+                    final=end, num_files=num_files,
                     first=first, outdir=self.outdir,
                     prefix="cutadapt-", summarise=self.summarise,
                     options=self.cutadapt_opt, threads=self.threads,
                     adapters=self.adapters)
-                tool_cmd, post_cmd, infile, f_format, num_files = (
+                tool_cmd, post_cmd, infile, num_files = (
                     cutadapt_object.build(infile))
             else:
                 E.info("%s is not a supported tool" % tool)
@@ -393,22 +391,23 @@ class MasterProcessor():
             statement = 'checkpoint;'
         else:
             statement = 'rm -rf %s;' % self.outdir
+        statement += '''rm -rf %s;''' % (self.tmpdir_fastq)
         return statement
 
     def build(self, infile, outfile, processer_list):
-        '''run mapper.'''
-        f_format = Fastq.guessFormat(
-            IOTools.openFile(infile[0], "r"), raises=False)
+        '''run preprocessing'''
 
+        cmd_preprocess, procfile = self.preprocess(infile, outfile)
         cmd_process, cmd_post, processed_files = self.process(
-            infile[0], processer_list, outfile, f_format, save=self.save)
+            procfile[0], processer_list, outfile, save=self.save)
         cmd_clean = self.cleanup(outfile)
 
         assert cmd_process.strip().endswith(";")
         assert cmd_post.strip().endswith(";")
         assert cmd_clean.strip().endswith(";")
 
-        statement = " checkpoint; ".join((cmd_process,
+        statement = " checkpoint; ".join((cmd_preprocess,
+                                          cmd_process,
                                           cmd_post,
                                           cmd_clean))
         return statement
@@ -418,13 +417,12 @@ class process_tool(object):
     '''defines class attributes for a sequennce utility tool'''
 
     def __init__(self, first=True, final=True, compress=False,
-                 save=True, f_format="", num_files="", prefix="",
+                 save=True, num_files="", prefix="",
                  outdir="", infiles=(), summarise=False, options=None,
                  threads=1, adapters=None, *args, **kwargs):
         self.final = final
         self.compress = compress
         self.first = first
-        self.f_format = f_format
         self.num_files = num_files
         self.prefix = prefix
         self.summarise = summarise
@@ -439,7 +437,7 @@ class process_tool(object):
             self.outdir = outdir
 
     def setfastqAttr(self, infiles):
-        self.offset = Fastq.getOffset(self.f_format, raises=False)
+        self.offset = Fastq.getOffset("sanger", raises=False)
 
     def process(self, infiles):
         return ("", infiles)
@@ -481,7 +479,7 @@ class process_tool(object):
         post_cmd = self.postprocess(fastq_outfiles)
 
         return (process_cmd, post_cmd, fastq_outfiles,
-                self.f_format, self.num_files)
+                self.num_files)
 
 
 class trimgalore(process_tool):

--- a/CGATPipelines/PipelinePreprocess.py
+++ b/CGATPipelines/PipelinePreprocess.py
@@ -271,9 +271,6 @@ class MasterProcessor(Mapping.Mapper):
     # compress temporary fastq files with gzip
     compress = False
 
-    # convert to sanger quality scores
-    convert = False
-
     def __init__(self, save=True, summarise=False,
                  threads=1,
                  trimgalore_options=None,
@@ -324,7 +321,10 @@ class MasterProcessor(Mapping.Mapper):
         save_intermediates = save
         first = 1
 
-        if infile.endswith(".fastq.1.gz"):
+        # Some data can be tuples if passed on from preprocessing
+        if not isinstance(infile, basestring):
+            infiles = infile
+        elif infile.endswith(".fastq.1.gz"):
             bn = P.snip(infile, ".fastq.1.gz")
             infile2 = "%s.fastq.2.gz" % bn
             if not os.path.exists(infile2):

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -170,7 +170,7 @@ UNPROCESSED_INPUT_GLOB = INPUT_FORMATS
 
 # List of processed (trimmed, etc) input files
 PROCESSED_INPUT_GLOB = [os.path.join("processed.dir", x)
-                        for x in INPUT_FORMATS]
+                        for x in ["*.fastq.1.gz", "*.fastq.gz"]]
 
 
 def connect():
@@ -323,7 +323,7 @@ def loadFastqc(infile, outfile):
          mkdir(os.path.join(PARAMS["exportdir"], "fastq_screen")))
 @transform(UNPROCESSED_INPUT_GLOB + PROCESSED_INPUT_GLOB,
            REGEX_TRACK_BOTH,
-           r"%s/fastq_screen/\2.fastq.1_screen.png" % PARAMS['exportdir'])
+           r"%s/fastq_screen/\2.fastqscreen" % PARAMS['exportdir'])
 def runFastqScreen(infiles, outfile):
     '''run FastqScreen on input files.'''
 
@@ -342,8 +342,8 @@ def runFastqScreen(infiles, outfile):
     m = PipelineMapping.FastqScreen()
     statement = m.build((infiles,), outfile)
     P.run()
-
     shutil.rmtree(tempdir)
+    P.touch(outfile)
 
 
 @merge(runFastqc, "status_summary.tsv.gz")

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -236,17 +236,6 @@ if PARAMS.get("preprocessors", None):
         '''process reads from .fastq format files
         Tasks specified in PREPROCESSTOOLS are run in order
         '''
-        if ((infile.endswith(".csfasta.gz") or
-             infile.endswith(".csfasta.F3.gz") or
-             infile.endswith(".sra") or
-             infile.endswith(".export.txt.gz") or
-             infile.endswith(".fa.gz"))):
-            raise NotImplementedError('''preprocessing of ".sra", "csfasta" (solid)
-            ".export.txt.gz" or ".fa.gz" files is not currently implemented.
-            Infile: %(infile)s''' % locals())
-        else:
-            pass
-
         trimmomatic_options = PARAMS["trimmomatic_options"]
         if PARAMS["adapter_file"] or PARAMS["trimmomatic_adapter"]:
             if PARAMS["adapter_file"]:

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -267,6 +267,7 @@ if PARAMS.get("preprocessors", None):
         statement = m.build((infile,), outfile, PREPROCESSTOOLS)
 
         P.run()
+        P.touch(outfile)
 
 else:
     @follows(mkdir("processed.dir"))


### PR DESCRIPTION
- Preprocessing is now an instance of the Mapper Class (Fixes issue #35 )
- Preprocessing now includes conversion to Sanger Format
- MakeAdaptorFasta (PipelineMapping) can now handle both single and paired end SRAs
- Filenames of SRA contents are handled correctly
- Optimisation of Ruffus Workflow in PipelinReadQC
