### PR TITLE
Fix for STAR memory issues

### DIFF
--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -1971,7 +1971,6 @@ class STAR(Mapper):
             %(executable)s
                    --runMode alignReads
                    --runThreadN %%(star_threads)i
-                   --genomeLoad LoadAndRemove
                    --genomeDir %%(star_index_dir)s/%%(star_mapping_genome)s.dir
                    --outFileNamePrefix %(tmpdir)s/
                    --outStd SAM
@@ -1999,7 +1998,6 @@ class STAR(Mapper):
             %(executable)s
                    --runMode alignReads
                    --runThreadN %%(star_threads)i
-                   --genomeLoad LoadAndRemove
                    --genomeDir %%(star_index_dir)s/%%(star_mapping_genome)s.dir
                    --outFileNamePrefix %(tmpdir)s/
                    --outStd SAM


### PR DESCRIPTION
removes all "-genomeLoad" options which means STAR will go back to its default, which is equivalent to: "-genomeLoad NoSharedMemory". Possible Fix for #53 
