### PR TITLE
Minor alterations to PipelineUtilites to correctly pick up database 

### DIFF
--- a/CGATPipelines/PipelineUtilities.py
+++ b/CGATPipelines/PipelineUtilities.py
@@ -52,7 +52,7 @@ def db_execute(cc, statements):
         cc.execute(statement)
 
 
-def execute(queries, database=PARAMS.get("database", ""), attach=False):
+def execute(queries, database=PARAMS.get("database_name", ""), attach=False):
     '''Execute a statement or a  list of statements (sequentially)'''
 
     dbhandle = sqlite3.connect(database)
@@ -65,7 +65,7 @@ def execute(queries, database=PARAMS.get("database", ""), attach=False):
     cc.close()
 
 
-def fetch(query, database=PARAMS.get("database", ""), attach=False):
+def fetch(query, database=PARAMS.get("database_name", ""), attach=False):
     '''Fetch all query results and return'''
 
     try:
@@ -84,7 +84,7 @@ def fetch(query, database=PARAMS.get("database", ""), attach=False):
 
 
 def fetch_with_names(query,
-                     database=PARAMS.get("database", ""),
+                     database=PARAMS.get("database_name", ""),
                      attach=False):
     '''Fetch query results and returns them as an array of row arrays, in
        which the first entry is an array of the field names
@@ -115,7 +115,7 @@ def fetch_with_names(query,
 
 
 def fetch_DataFrame(query,
-                    database=PARAMS.get("database", ""),
+                    database=PARAMS.get("database_name", ""),
                     attach=False):
     '''Fetch query results and returns them as a pandas dataframe'''
 
@@ -149,7 +149,7 @@ def fetch_DataFrame(query,
 
 def write_DataFrame(dataframe,
                     tablename,
-                    database=PARAMS.get("database", ""),
+                    database=PARAMS.get("database_name", ""),
                     index=False,
                     if_exists='replace'):
     '''write a pandas dataframe to an sqlite db, index on given columns


### PR DESCRIPTION
Make the default place to look for database PARAMS["database_name"] rather than PARAMS["database"] in PipelineUtilities
