### PR TITLE
compression detection when mapping with STAR corrected

### DIFF
--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -2015,12 +2015,12 @@ class STAR(Mapper):
             infiles1 = " ".join([x[0] for x in infiles])
             infiles2 = " ".join([x[1] for x in infiles])
 
-            # patch for compressed files
             if infiles[0][0].endswith(".gz"):
-                files = "<( zcat %(infiles1)s ) <( zcat %(infiles2)s )" % \
-                        locals()
+                compress_option = "--readFilesCommand zcat"
             else:
-                files = "%(infiles1)s %(infiles2)s" % locals()
+                compress_option = ""
+
+            files = "%(infiles1)s %(infiles2)s" % locals()
 
             statement = '''
             %(executable)s
@@ -2031,6 +2031,7 @@ class STAR(Mapper):
                    --outStd SAM
                    --outSAMunmapped Within
                    %%(star_options)s
+                   %(compress_option)s
                    --readFilesIn %(files)s
                    > %(tmpdir)s/%(track)s.sam
                    2> %(outfile)s.log;


### PR DESCRIPTION
Previously, gzipped fastq files were unzipped on the fly when mapping with STAR. This is fine for one-pass alignment but fails for two pass alignment. Presumably because the stdin is empty on the second pass. 

STAR actually has an option to deal with compressed input (--readFilesCommand) which is now used instead.
