### PR TITLE
Is static cwd

### DIFF
--- a/CGATPipelines/Pipeline.py
+++ b/CGATPipelines/Pipeline.py
@@ -204,6 +204,7 @@ Local.CONFIG = CONFIG
 
 WORKING_DIRECTORY = os.getcwd()
 
+
 class PipelineError(Exception):
     pass
 

--- a/CGATPipelines/Pipeline.py
+++ b/CGATPipelines/Pipeline.py
@@ -202,6 +202,7 @@ INTERPOLATE_PARAMS = ('cmd-farm', 'cmd-run')
 Local.PARAMS = PARAMS
 Local.CONFIG = CONFIG
 
+WORKING_DIRECTORY = os.getcwd()
 
 class PipelineError(Exception):
     pass
@@ -1139,7 +1140,7 @@ def execute(statement, **kwargs):
     L.debug("running %s" % (statement % kwargs))
 
     if "cwd" not in kwargs:
-        cwd = os.getcwd()
+        cwd = WOKRING_DIRECTORY
     else:
         cwd = kwargs["cwd"]
 
@@ -1430,7 +1431,7 @@ def run(**kwargs):
     def setupJob(session, options, job_memory, job_name):
 
         jt = session.createJobTemplate()
-        jt.workingDirectory = os.getcwd()
+        jt.workingDirectory = WORKING_DIRECTORY
         jt.jobEnvironment = {'BASH_ENV': '~/.bashrc'}
         jt.args = []
         if not re.match("[a-zA-Z]", job_name[0]):
@@ -1458,7 +1459,7 @@ def run(**kwargs):
 
         return jt
 
-    shellfile = os.path.join(os.getcwd(), "shell.log")
+    shellfile = os.path.join(WORKING_DIRECTORY, "shell.log")
 
     pid = os.getpid()
     L.debug('task: pid = %i' % pid)
@@ -1490,7 +1491,7 @@ def run(**kwargs):
         returns (name_of_script, stdout_path, stderr_path)
         '''
 
-        tmpfile = getTempFile(dir=os.getcwd())
+        tmpfile = getTempFile(dir=WORKING_DIRECTORY)
         # disabled: -l -O expand_aliases\n" )
         tmpfile.write("#!/bin/bash\n")
         tmpfile.write(
@@ -1667,7 +1668,7 @@ def run(**kwargs):
                 expandStatement(
                     statement,
                     ignore_pipe_errors=ignore_pipe_errors),
-                cwd=os.getcwd(),
+                cwd=WOKRING_DIRECTORY,
                 shell=True,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
@@ -2516,7 +2517,7 @@ def main(args=sys.argv):
                               add_cluster_options=True)
 
     GLOBAL_OPTIONS, GLOBAL_ARGS = options, args
-
+    E.info("Started in: %s" % WORKING_DIRECTORY)
     # At this point, the PARAMS dictionary has already been
     # built. It now needs to be updated with selected command
     # line options as these should always take precedence over
@@ -2644,6 +2645,8 @@ def main(args=sys.argv):
                 L.info(E.GetHeader())
                 L.info("code location: %s" % PARAMS["pipeline_scriptsdir"])
                 L.info("code version: %s" % version)
+                L.info("Working directory is: %s" % WORKING_DIRECTORY)
+
                 pipeline_run(
                     options.pipeline_targets,
                     multiprocess=options.multiprocess,

--- a/CGATPipelines/Pipeline.py
+++ b/CGATPipelines/Pipeline.py
@@ -1140,7 +1140,7 @@ def execute(statement, **kwargs):
     L.debug("running %s" % (statement % kwargs))
 
     if "cwd" not in kwargs:
-        cwd = WOKRING_DIRECTORY
+        cwd = WORKING_DIRECTORY
     else:
         cwd = kwargs["cwd"]
 
@@ -1668,7 +1668,7 @@ def run(**kwargs):
                 expandStatement(
                     statement,
                     ignore_pipe_errors=ignore_pipe_errors),
-                cwd=WOKRING_DIRECTORY,
+                cwd=WORKING_DIRECTORY,
                 shell=True,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
We've been having some trouble with repeated calls to os.getcwd(). Just occasionally it returns `~` for no reason. Thus in this fix, the working directory is queried at start time and then stored in a global variable. 
