### PR TITLE
check for presence of BioMart before quering mart

### DIFF
--- a/CGATPipelines/pipeline_annotations.py
+++ b/CGATPipelines/pipeline_annotations.py
@@ -939,6 +939,7 @@ def buildGenomeGCProfile(infile, outfile):
         --log=%(outfile)s.log
     | bgzip
     > %(outfile)s'''
+
     P.run()
 
 
@@ -1166,6 +1167,11 @@ def downloadTranscriptInformation(infile, outfile):
        in mart to output table.
     '''
 
+    # If mart is not set, use old fasionhed gtf parsing
+    if not PARAMS["ensembl_biomart_mart"]:
+        PipelineGeneset.loadTranscriptInformation(infile, outfile)
+        return
+
     tablename = P.toTable(outfile)
 
     # only use transcript relevant information. Uniprot ids
@@ -1272,6 +1278,11 @@ def downloadEntrezToEnsembl(infile, outfile):
        Biomart host to use.
 
     '''
+    
+    if not PARAMS["ensembl_biomart_mart"]:
+        #skip
+        P.touch(outfile)
+        return None
 
     tablename = P.toTable(outfile)
 
@@ -1325,8 +1336,13 @@ def downloadTranscriptSynonyms(infile, outfile):
 
     """
 
+    if not PARAMS["ensembl_biomart_mart"]:
+        #skip
+        P.touch(outfile)
+        return None
+        
     tablename = P.toTable(outfile)
-
+    
     columns = {
         "ensembl_transcript_id": "transcript_id",
         "external_transcript_name": "transcript_name",


### PR DESCRIPTION
These changes allow no biomart to be specified if you are working on a non-biomart organism. It defaults to using gtf parsing to pull in transcription information. 
