### PR TITLE
added option to reroute untrimmed reads to cutadapt

### DIFF
--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -256,7 +256,8 @@ if PARAMS.get("preprocessors", None):
     def processReads(infile, outfiles):
         '''process reads from .fastq and other sequence files.
         '''
-
+        print "infile", infile
+        print "outfiles", outfiles
         trimmomatic_options = PARAMS["trimmomatic_options"]
         if PARAMS["trimmomatic_adapter"]:
             trimmomatic_options = " ILLUMINACLIP:%s:%s:%s:%s " % (
@@ -310,7 +311,8 @@ if PARAMS.get("preprocessors", None):
                     cutadapt_options += " -a file:contaminants.fasta "
                 m.add(PipelinePreprocess.Cutadapt(
                     cutadapt_options,
-                    threads=PARAMS["threads"]))
+                    threads=PARAMS["threads"],
+                    untrimmed=PARAMS['cutadapt_reroute_untrimmed']))
 
         statement = m.build((infile,), "processed.dir/trimmed-", track)
 

--- a/CGATPipelines/pipeline_readqc/pipeline.ini
+++ b/CGATPipelines/pipeline_readqc/pipeline.ini
@@ -140,6 +140,9 @@ options=-m 15 -M 50 -r 50 -f 300
 # use -a file:PATH to provide a fasta file of multiple adapters
 # -q quality threshold
 # if auto_remove is set then make sure there are no -a flags here
+# if reroute_untrimmed == 1 untrimmed reads are sent to a different
+# output file which is not then processed in the next step
+reroute_untrimmed=0
 options=-a AGATCGGAAGAGC --overlap 18 --minimum-length 25 --maximum-length 28 -q 20
 
 


### PR DESCRIPTION
Cutadapt can send the trimmed reads to stdout but the untrimmed reads to another fastq file, added this option to the pipeline.
