### PR TITLE
added option to not run fastq_screen

### DIFF
--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -140,7 +140,7 @@ Requirements:
 
 # import ruffus
 from ruffus import transform, merge, follows, mkdir, regex, suffix, jobs_limit, \
-    subdivide, collate
+    subdivide, collate, active_if
 
 # import useful standard python modules
 import sys
@@ -371,6 +371,7 @@ def loadFastqc(infile, outfile):
 
 @follows(mkdir(PARAMS["exportdir"]),
          mkdir(os.path.join(PARAMS["exportdir"], "fastq_screen")))
+@active_if(PARAMS["fastq_screen_run"] == 1)
 @transform((unprocessReads, processReads),
            regex(REGEX_TRACK_BOTH),
            r"%s/fastq_screen/\2.fastqscreen" % PARAMS['exportdir'])

--- a/CGATPipelines/pipeline_readqc/pipeline.ini
+++ b/CGATPipelines/pipeline_readqc/pipeline.ini
@@ -158,6 +158,8 @@ no_group=0
 ##### fastq_screen options
 ################################################################
 [fastq_screen]
+# only run fastq_screen if this is 1
+run=1
 # --threads
 # --subset: subset of genome to be analysed
 options=--threads 10 --subset 100000


### PR DESCRIPTION
Made running fastq_screen optional in pipeline_readqc as it is quite slow and not always needed.
