### PR TITLE
SLURM

### DIFF
--- a/CGATPipelines/Pipeline/Execution.py
+++ b/CGATPipelines/Pipeline/Execution.py
@@ -565,10 +565,10 @@ def run(**kwargs):
             #
             # TODO: add "--account" (not sure the best way to fill param).
 
-        spec = ["-J %s" % job_name,
-                "--mem-per-cpu=%s" % job_memory_per_cpu,
-                "--cpus-per-task=%s" % job_threads,
-                "%(cluster_options)s"]
+            spec = ["-J %s" % job_name,
+                    "--mem-per-cpu=%s" % job_memory_per_cpu,
+                    "--cpus-per-task=%s" % job_threads,
+                    "%(cluster_options)s"]
 
         else:
             raise ValueError("Queue manager %s not supported" % queue_manager)

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -135,6 +135,8 @@ HARDCODED_PARAMS = {
     'tmpdir': os.environ.get("TMPDIR", '/scratch'),
     # directory used for temporary files shared across machines
     'shared_tmpdir': os.environ.get("SHARED_TMPDIR", "/ifs/scratch"),
+    # queue manager (supported: sge, slurm)
+    'queue_manager': 'sge',
     # cluster queue to use
     'cluster_queue': 'all.q',
     # priority of jobs in cluster queue
@@ -214,6 +216,7 @@ def configToDictionary(config):
 
 def getParameters(filenames=["pipeline.ini", ],
                   defaults=None,
+                  site_ini=True,
                   user_ini=True,
                   default_ini=True,
                   only_import=None):
@@ -304,6 +307,13 @@ def getParameters(filenames=["pipeline.ini", ],
     if only_import:
         # turn on default dictionary
         TriggeredDefaultFactory.with_default = True
+
+    if site_ini:
+        # SNS: I propose that all hardcoded PARAMs be moved to here
+        # read configuration from /etc
+        fn = "/etc/cgat/pipeline.ini"
+        if os.path.exists(fn):
+            filenames.insert(0, fn)
 
     if user_ini:
         # read configuration from a users home directory
@@ -533,4 +543,3 @@ def checkParameter(param):
 def getParams():
     """return handle to global parameter dictionary"""
     return PARAMS
-


### PR DESCRIPTION
Andreas/Sebastian please take a look!

This: 

(1) adds support for the SLURM queue manager assuming that it is configured with consumable resources as commented in the code (a standard configuration profile).

We are using SLURM on our cluster so this should get extensive testing.

(2) implements site-wide configuration in /etc/cgat/. Here /etc/cgat/pipeline.ini is used for pipeline configuration, analogously /etc/cgat/scripts.ini could be used for the CGAT scripts collection.

This is needed to allow straightforward (i.e. administrator rather than user configured)  deployment of the code on foreign clusters.
