### PR TITLE
Refactor Pipeline module DRMAA abstraction into Cluster.py sub-module.

### DIFF
--- a/CGATPipelines/Pipeline/Cluster.py
+++ b/CGATPipelines/Pipeline/Cluster.py
@@ -1,0 +1,295 @@
+##########################################################################
+#
+#   MRC FGU Computational Genomics Group
+#
+#   $Id$
+#
+#   Copyright (C) 2016 Stephen Sansom
+#
+#   This program is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License
+#   as published by the Free Software Foundation; either version 2
+#   of the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+##########################################################################
+'''Cluster.py - cluster utility functions for ruffus pipelines
+==============================================================
+
+This module abstracts the DRMAA native specification and provides
+convenience functions for running Drmaa jobs.
+
+
+Reference
+---------
+
+'''
+
+import re
+import os
+import stat
+import drmaa
+
+
+def setupDrmaaJobTemplate(drmaa_session, options, job_name, job_memory):
+    '''Sets up a Drmma job template. Currently SGE and SLURM are
+       supported'''
+
+    if not job_memory:
+        raise ValueError("Job memory must be specified when running"
+                         "DRMAA jobs")
+
+    jt = drmaa_session.createJobTemplate()
+    jt.workingDirectory = options["workingdir"]
+    jt.jobEnvironment = {'BASH_ENV': '~/.bashrc'}
+    jt.args = []
+    if not re.match("[a-zA-Z]", job_name[0]):
+        job_name = "_" + job_name
+
+    # queue manager specific configuration options
+    queue_manager = options["cluster_queue_manager"]
+
+    if queue_manager.lower() == "sge":
+
+        # see: ? cannot find documentation on the SGE native spec
+
+        spec = ["-V",
+                "-N %s" % job_name]
+
+        if options["cluster_priority"]:
+            spec.append("-p %(cluster_priority)i")
+
+        if options["cluster_options"]:
+            spec.append("%(cluster_options)s")
+
+        if not options["cluster_memory_resource"]:
+            raise ValueError("The cluster memory resource must be specified")
+
+        for resource in options["cluster_memory_resource"].split(","):
+            spec.append("-l %s=%s" % (resource, job_memory))
+
+        # if process has multiple threads, use a parallel environment
+        if 'job_threads' in options:
+            spec.append(
+                "-pe %(cluster_parallel_environment)s %(job_threads)i -R y")
+
+            if "cluster_pe_queue" in options and 'job_threads' in options:
+                spec.append(
+                    "-q %(cluster_pe_queue)s")
+        else:
+            spec.append("-q %(cluster_queue)s")
+
+    elif queue_manager.lower() == "slurm":
+
+        # SLURM DOCS:
+        # http://apps.man.poznan.pl/trac/slurm-drmaa
+        # https://computing.llnl.gov/linux/slurm/cons_res_share.html
+        #
+        # The SLURM Consumable Resource plugin is required
+        # The "CR_CPU_Memory" resource must be specified
+        #
+        # i.e. in slurm.conf:
+        # SelectType=select/cons_res
+        # SelectTypeParameters=CR_CPU_Memory
+        #
+        # * Note that --cpus-per-task will actually refer to cores
+        #   with the appropriate Node configuration
+        #
+        # SLURM-DRMAA DOCS - Note that version 1.2 (SVN) is required
+        # http://apps.man.poznan.pl/trac/slurm-drmaa
+        #
+        # Not implemented:
+        # -V: SLURM automatically passess the environment variables
+        # -p: does not appear to be part of the slurm drmaa native spec
+        #
+        # TODO: add "--account" (not sure the best way to fill param).
+
+        spec = ["-J %s" % job_name]
+
+        if options["cluster_options"]:
+            spec.append("%(cluster_options)s")
+
+        if 'job_threads' in options:
+            job_threads = options["job_threads"]
+        else:
+            job_threads = 1  # probably should come from a config option
+
+        spec.append("--cpus-per-task=%s" % job_threads)
+
+        # Note the that the specified memory must be per CPU
+        # for consistency with the implemented SGE approach
+
+        if job_memory.endswith("G"):
+            job_memory_per_cpu = int(job_memory[:-1]) * 1000
+        elif job_memory.endswith("M"):
+            job_memory_per_cpu = int(job_memory[:-1])
+        else:
+            raise ValueError('job memory unit not recognised for SLURM, '
+                             'must be either "M" (for Mb) or "G" (for Gb),'
+                             ' e.g. 1G or 1000M for 1 Gigabyte of memory')
+
+        spec.append("--mem-per-cpu=%s" % job_memory_per_cpu)
+
+    else:
+        raise ValueError("Queue manager %s not supported" % queue_manager)
+
+    jt.nativeSpecification = " ".join(spec) % options
+
+    # keep stdout and stderr separate
+    jt.joinFiles = False
+
+    return jt
+
+
+def setDrmaaJobPaths(job_template, job_path):
+    '''Adds the job_path, stdout_path and stderr_paths
+       to the job_template.
+    '''
+    job_path = os.path.abspath(job_path)
+
+    os.chmod(job_path, stat.S_IRWXG | stat.S_IRWXU)
+
+    stdout_path = job_path + ".stdout"
+    stderr_path = job_path + ".stderr"
+
+    job_template.remoteCommand = job_path
+    job_template.outputPath = ":" + stdout_path
+    job_template.errorPath = ":" + stderr_path
+
+    return job_template, stdout_path, stderr_path
+
+
+def expandStatement(statement, ignore_pipe_errors=False):
+    '''add generic commands before and after statement.
+
+    The prefixes and suffixes added are defined in :data:`exec_prefix`
+    and :data:`exec_suffix`. The main purpose of these prefixs is to
+    provide error detection code to detect errors at early steps in a
+    series of unix commands within a pipe.
+
+    Arguments
+    ---------
+    statement : string
+        Command line statement to expand
+    ignore_pipe_errors : bool
+        If False, do not modify statement.
+
+    Returns
+    -------
+    statement : string
+        The expanded statement.
+
+    '''
+
+    _exec_prefix = '''detect_pipe_error_helper()
+        {
+        while [ "$#" != 0 ] ; do
+            # there was an error in at least one program of the pipe
+            if [ "$1" != 0 ] ; then return 1 ; fi
+            shift 1
+        done
+        return 0
+        }
+        detect_pipe_error() {
+        detect_pipe_error_helper "${PIPESTATUS[@]}"
+        return $?
+        }
+        checkpoint() {
+            detect_pipe_error;
+            if [ $? != 0 ]; then exit 1; fi;
+        }
+        '''
+
+    _exec_suffix = "; detect_pipe_error"
+
+    if ignore_pipe_errors:
+        return statement
+    else:
+        return " ".join((_exec_prefix, statement, _exec_suffix))
+
+
+def collectSingleJobFromCluster(session, job_id,
+                                statement,
+                                stdout_path, stderr_path,
+                                job_path,
+                                ignore_errors=False):
+    '''runs a single job on the cluster.'''
+    try:
+        retval = session.wait(
+            job_id, drmaa.Session.TIMEOUT_WAIT_FOREVER)
+    except Exception, msg:
+        # ignore message 24 in PBS code 24: drmaa: Job
+        # finished but resource usage information and/or
+        # termination status could not be provided.":
+        if not msg.message.startswith("code 24"):
+            raise
+        retval = None
+
+    stdout, stderr = getStdoutStderr(stdout_path, stderr_path)
+
+    if retval and retval.exitStatus != 0 and not ignore_errors:
+        raise OSError(
+            "---------------------------------------\n"
+            "Child was terminated by signal %i: \n"
+            "The stderr was: \n%s\n%s\n"
+            "-----------------------------------------" %
+            (retval.exitStatus,
+             "".join(stderr), statement))
+
+    try:
+        os.unlink(job_path)
+    except OSError:
+        E.warn(
+            ("temporary job file %s not present for "
+             "clean-up - ignored") % job_path)
+
+
+def getStdoutStderr(stdout_path, stderr_path, tries=5):
+    '''get stdout/stderr allowing for same lag.
+
+    Try at most *tries* times. If unsuccessfull, throw OSError
+
+    Removes the files once they are read.
+
+    Returns tuple of stdout and stderr.
+    '''
+    x = tries
+    while x >= 0:
+        if os.path.exists(stdout_path):
+            break
+        time.sleep(1)
+        x -= 1
+
+    x = tries
+    while x >= 0:
+        if os.path.exists(stderr_path):
+            break
+        time.sleep(1)
+        x -= 1
+
+    try:
+        stdout = open(stdout_path, "r").readlines()
+    except IOError, msg:
+        E.warn("could not open stdout: %s" % msg)
+        stdout = []
+
+    try:
+        stderr = open(stderr_path, "r").readlines()
+    except IOError, msg:
+        E.warn("could not open stdout: %s" % msg)
+        stderr = []
+
+    try:
+        os.unlink(stdout_path)
+        os.unlink(stderr_path)
+    except OSError, msg:
+        pass
+
+    return stdout, stderr

--- a/CGATPipelines/Pipeline/Cluster.py
+++ b/CGATPipelines/Pipeline/Cluster.py
@@ -35,8 +35,12 @@ Reference
 import re
 import os
 import stat
-import drmaa
 
+try:
+    import drmaa
+    HAS_DRMAA = True
+except RuntimeError:
+    HAS_DRMAA = False
 
 def setupDrmaaJobTemplate(drmaa_session, options, job_name, job_memory):
     '''Sets up a Drmma job template. Currently SGE and SLURM are

--- a/CGATPipelines/Pipeline/Execution.py
+++ b/CGATPipelines/Pipeline/Execution.py
@@ -1,4 +1,4 @@
-##########################################################################
+###########################################################################
 #
 #   MRC FGU Computational Genomics Group
 #
@@ -61,6 +61,7 @@ PARAMS = {}
 from CGATPipelines.Pipeline.Utils import getCallerLocals
 from CGATPipelines.Pipeline.Parameters import substituteParameters
 from CGATPipelines.Pipeline.Files import getTempFilename, getTempFile
+from CGATPipelines.Pipeline.Cluster import *
 
 # global drmaa session
 GLOBAL_SESSION = None
@@ -179,26 +180,6 @@ def execute(statement, **kwargs):
 # detect_pipe_error(): propagate error of programs not at the end of a pipe
 # checkpoint(): exit a set of chained commands (via ;) if the previous
 # command failed.
-_exec_prefix = '''detect_pipe_error_helper()
-    {
-    while [ "$#" != 0 ] ; do
-        # there was an error in at least one program of the pipe
-        if [ "$1" != 0 ] ; then return 1 ; fi
-        shift 1
-    done
-    return 0
-    }
-    detect_pipe_error() {
-    detect_pipe_error_helper "${PIPESTATUS[@]}"
-    return $?
-    }
-    checkpoint() {
-        detect_pipe_error;
-        if [ $? != 0 ]; then exit 1; fi;
-    }
-    '''
-
-_exec_suffix = "; detect_pipe_error"
 
 
 def buildStatement(**kwargs):
@@ -251,34 +232,6 @@ def buildStatement(**kwargs):
     return statement
 
 
-def expandStatement(statement, ignore_pipe_errors=False):
-    '''add generic commands before and after statement.
-
-    The prefixes and suffixes added are defined in :data:`exec_prefix`
-    and :data:`exec_suffix`. The main purpose of these prefixs is to
-    provide error detection code to detect errors at early steps in a
-    series of unix commands within a pipe.
-
-    Arguments
-    ---------
-    statement : string
-        Command line statement to expand
-    ignore_pipe_errors : bool
-        If False, do not modify statement.
-
-    Returns
-    -------
-    statement : string
-        The expanded statement.
-
-    '''
-
-    if ignore_pipe_errors:
-        return statement
-    else:
-        return " ".join((_exec_prefix, statement, _exec_suffix))
-
-
 def joinStatements(statements, infile):
     '''join a chain of statements into a single statement.
 
@@ -326,84 +279,42 @@ def joinStatements(statements, infile):
     return result
 
 
-def getStdoutStderr(stdout_path, stderr_path, tries=5):
-    '''get stdout/stderr allowing for same lag.
+def getJobMemory(options=False, PARAMS=False):
+    '''Extract the job memory from an options or
+       or PARAMS dictionaries'''
 
-    Try at most *tries* times. If unsuccessfull, throw OSError
+    job_memory = None
+    if options and 'job_memory' in options:
+        job_memory = options['job_memory']
 
-    Removes the files once they are read.
+    elif options and "mem_free" in options["cluster_options"] and \
+        PARAMS.get("cluster_memory_resource", False):
 
-    Returns tuple of stdout and stderr.
-    '''
-    x = tries
-    while x >= 0:
-        if os.path.exists(stdout_path):
-            break
-        time.sleep(1)
-        x -= 1
+        E.warn("use of mem_free in job options is deprecated, please"
+               " set job_memory local var instead")
 
-    x = tries
-    while x >= 0:
-        if os.path.exists(stderr_path):
-            break
-        time.sleep(1)
-        x -= 1
+        o = options["cluster_options"]
+        x = re.search("-l\s*mem_free\s*=\s*(\S+)", o)
+        if x is None:
+            raise ValueError(
+                "expecting mem_free in '%s'" % o)
 
-    try:
-        stdout = open(stdout_path, "r").readlines()
-    except IOError, msg:
-        E.warn("could not open stdout: %s" % msg)
-        stdout = []
+        job_memory = x.groups()[0]
 
-    try:
-        stderr = open(stderr_path, "r").readlines()
-    except IOError, msg:
-        E.warn("could not open stdout: %s" % msg)
-        stderr = []
+        # remove memory spec from job options
+        options["cluster_options"] = re.sub(
+            "-l\s*mem_free\s*=\s*(\S+)", "", o)
+    elif PARAMS:
+        job_memory = PARAMS["cluster_memory_default"]
+        # SNS not sure why this was hard coded
+        # PARAMS.get("cluster_memory_default", "2G")
+        # consider better to fail if not set.
+    else:
+        raise ValueError('Job memory must be specified for DRMAA jobs'
+                         ' using either the "job_memory" option or the'
+                         ' "cluster_memory_default" parameter')
 
-    try:
-        os.unlink(stdout_path)
-        os.unlink(stderr_path)
-    except OSError, msg:
-        pass
-
-    return stdout, stderr
-
-
-def _collectSingleJobFromCluster(session, job_id,
-                                 statement,
-                                 stdout_path, stderr_path,
-                                 job_path,
-                                 ignore_errors=False):
-    '''runs a single job on the cluster.'''
-    try:
-        retval = session.wait(
-            job_id, drmaa.Session.TIMEOUT_WAIT_FOREVER)
-    except Exception, msg:
-        # ignore message 24 in PBS code 24: drmaa: Job
-        # finished but resource usage information and/or
-        # termination status could not be provided.":
-        if not msg.message.startswith("code 24"):
-            raise
-        retval = None
-
-    stdout, stderr = getStdoutStderr(stdout_path, stderr_path)
-
-    if retval and retval.exitStatus != 0 and not ignore_errors:
-        raise OSError(
-            "---------------------------------------\n"
-            "Child was terminated by signal %i: \n"
-            "The stderr was: \n%s\n%s\n"
-            "-----------------------------------------" %
-            (retval.exitStatus,
-             "".join(stderr), statement))
-
-    try:
-        os.unlink(job_path)
-    except OSError:
-        E.warn(
-            ("temporary job file %s not present for "
-             "clean-up - ignored") % job_path)
+    return job_memory
 
 
 def run(**kwargs):
@@ -463,123 +374,11 @@ def run(**kwargs):
                                            options['cluster_queue'])
     options['without_cluster'] = options.get('without_cluster')
 
-    job_memory = None
+    # get the memory requirement for the job
+    job_memory = getJobMemory(options, PARAMS)
 
-    if 'job_memory' in options:
-        job_memory = options['job_memory']
-
-    elif "mem_free" in options["cluster_options"] and \
-         PARAMS.get("cluster_memory_resource", False):
-
-        E.warn("use of mem_free in job options is deprecated, please"
-               " set job_memory local var instead")
-
-        o = options["cluster_options"]
-        x = re.search("-l\s*mem_free\s*=\s*(\S+)", o)
-        if x is None:
-            raise ValueError(
-                "expecting mem_free in '%s'" % o)
-
-        job_memory = x.groups()[0]
-
-        # remove memory spec from job options
-        options["cluster_options"] = re.sub(
-            "-l\s*mem_free\s*=\s*(\S+)", "", o)
-    else:
-        job_memory = PARAMS.get("cluster_memory_default", "2G")
-
-    def setupJob(session, options, job_memory, job_name):
-
-        jt = session.createJobTemplate()
-        jt.workingDirectory = PARAMS["workingdir"]
-        jt.jobEnvironment = {'BASH_ENV': '~/.bashrc'}
-        jt.args = []
-        if not re.match("[a-zA-Z]", job_name[0]):
-            job_name = "_" + job_name
-
-        # queue manager specific configuration options
-
-        queue_manager = PARAMS["queue_manager"]
-
-        if queue_manager.lower() == "sge":
-
-            # see: ? cannot find documentation on the SGE native spec
-
-            spec = ["-V",
-                    "-p %(cluster_priority)i",
-                    "-N %s" % job_name,
-                    "%(cluster_options)s"]
-
-            for resource in PARAMS["cluster_memory_resource"].split(","):
-                spec.append("-l %s=%s" % (resource, job_memory))
-
-            # if process has multiple threads, use a parallel environment
-            if 'job_threads' in options:
-                spec.append(
-                    "-pe %(cluster_parallel_environment)s %(job_threads)i -R y")
-            if "cluster_pe_queue" in options and 'job_threads' in options:
-                    spec.append(
-                        "-q %(cluster_pe_queue)s")
-            else:
-                spec.append("-q %(cluster_queue)s")
-
-        elif queue_manager.lower() == "slurm":
-
-            # SLURM DOCS:
-            # http://apps.man.poznan.pl/trac/slurm-drmaa
-            # https://computing.llnl.gov/linux/slurm/cons_res_share.html
-            #
-
-            if 'job_threads' in options:
-                job_threads = options["job_threads"]
-            else:
-                job_threads = 1  # probably should come from a config option
-
-            # Note the that the specified memory must be per CPU
-            # for consistency with the implemented SGE approach
-            if job_memory.endswith("G"):
-                job_memory_per_cpu = int(job_memory[:-1]) * 1000
-            elif job_memory.endswith("M"):
-                job_memory_per_cpu = int(job_memory[:-1])
-            else:
-                raise ValueError('job memory unit not recognised for SLURM, '
-                                 'must be either "M" (for Mb) or "G" (for Gb),'
-                                 ' e.g. 1G or 1000M for 1 Gigabyte of memory')
-
-            # The SLURM Consumable Resource plugin is required
-            # The "CR_CPU_Memory" resource must be specified
-            #
-            # i.e. in slurm.conf:
-            # SelectType=select/cons_res
-            # SelectTypeParameters=CR_CPU_Memory
-            #
-            # * Note that --cpus-per-task will actually refer to cores
-            #   with the appropriate Node configuration
-            #
-            # SLURM-DRMAA DOCS - Note that version 1.2 (SVN) is required
-            # http://apps.man.poznan.pl/trac/slurm-drmaa
-            #
-            # Not implemented:
-            # -V: cannot find documentation as to what this flag is for
-            # -p: does not appear to be part of the slurm drmaa native spec
-            #
-            # TODO: add "--account" (not sure the best way to fill param).
-
-            spec = ["-J %s" % job_name,
-                    "--mem-per-cpu=%s" % job_memory_per_cpu,
-                    "--cpus-per-task=%s" % job_threads,
-                    "%(cluster_options)s"]
-
-        else:
-            raise ValueError("Queue manager %s not supported" % queue_manager)
-
-        jt.nativeSpecification = " ".join(spec) % options
-        # keep stdout and stderr separate
-        jt.joinFiles = False
-
-        E.debug("Job spec is: %s" % jt.nativeSpecification)
-
-        return jt
+    # get the queue manager
+    queue_manager = PARAMS["cluster_queue_manager"]
 
     shellfile = os.path.join(PARAMS["workingdir"], "shell.log")
 
@@ -607,54 +406,37 @@ def run(**kwargs):
         "[:]", "_",
         os.path.basename(options.get("outfile", "ruffus")))
 
-    def buildJobScript(statement, job_memory, job_name):
-        '''build job script from statement.
-
-        returns (name_of_script, stdout_path, stderr_path)
-        '''
-
-        tmpfile = getTempFile(dir=PARAMS["workingdir"])
-        # disabled: -l -O expand_aliases\n" )
-        tmpfile.write("#!/bin/bash\n")
-        tmpfile.write(
-            'echo "%s : START -> %s" >> %s\n' %
-            (job_name, tmpfile.name, shellfile))
+    def _writeJobScript(statement, job_memory, job_name, shellfile):
         # disabled - problems with quoting
         # tmpfile.write( '''echo 'statement=%s' >> %s\n''' %
         # (shellquote(statement), shellfile) )
-        tmpfile.write("set | sed 's/^/%s : /' &>> %s\n" %
-                      (job_name, shellfile))
         # module list outputs to stderr, so merge stderr and stdout
-        tmpfile.write("module list 2>&1 | sed 's/^/%s: /' &>> %s\n" %
-                      (job_name, shellfile))
-        tmpfile.write("hostname | sed 's/^/%s: /' &>> %s\n" %
-                      (job_name, shellfile))
-        tmpfile.write("cat /proc/meminfo | sed 's/^/%s: /' &>> %s\n" %
-                      (job_name, shellfile))
-        tmpfile.write(
-            'echo "%s : END -> %s" >> %s\n' %
-            (job_name, tmpfile.name, shellfile))
+
+        script = '''#!/bin/bash\n
+                    echo "%(job_name)s : START -> ${0}" >> %(shellfile)s
+                    set | sed 's/^/%(job_name)s : /' &>> %(shellfile)s
+                    module list 2>&1 | sed 's/^/%(job_name)s: /' &>> %(shellfile)s
+                    hostname | sed 's/^/%(job_name)s: /' &>> %(shellfile)s
+                    cat /proc/meminfo | sed 's/^/%(job_name)s: /' &>> %(shellfile)s
+                    echo "%(job_name)s : END -> ${0}" >> %(shellfile)s
+                 ''' % locals()
 
         # restrict virtual memory
         # Note that there are resources in SGE which could do this directly
         # such as v_hmem.
         # Note that limiting resident set sizes (RSS) with ulimit is not
         # possible in newer kernels.
-        tmpfile.write("ulimit -v %i\n" % IOTools.human2bytes(job_memory))
+        script += "ulimit -v %i\n" % IOTools.human2bytes(job_memory)
+        script += expandStatement(statement,
+                                  ignore_pipe_errors=ignore_pipe_errors)
+        script += "\n"
 
-        tmpfile.write(
-            expandStatement(
-                statement,
-                ignore_pipe_errors=ignore_pipe_errors) + "\n")
-        tmpfile.close()
+        job_path = getTempFilename(dir=PARAMS["workingdir"])
 
-        job_path = os.path.abspath(tmpfile.name)
-        stdout_path = job_path + ".stdout"
-        stderr_path = job_path + ".stderr"
+        with open(job_path, "w") as script_file:
+            script_file.write(script)
 
-        os.chmod(job_path, stat.S_IRWXG | stat.S_IRWXU)
-
-        return (job_path, stdout_path, stderr_path)
+        return(job_path)
 
     if run_on_cluster:
         # run multiple jobs
@@ -668,29 +450,27 @@ def run(**kwargs):
             if options.get("dryrun", False):
                 return
 
-            jt = setupJob(session, options, job_memory, job_name)
+            jt = setupDrmaaJobTemplate(session, options, job_name, job_memory)
+            E.debug("Job spec is: %s" % jt.nativeSpecification)
 
             job_ids, filenames = [], []
+
             for statement in statement_list:
                 E.debug("running statement:\n%s" % statement)
 
-                job_path, stdout_path, stderr_path = buildJobScript(statement,
-                                                                    job_memory,
-                                                                    job_name)
+                job_path = _writeJobScript(statement, job_memory, job_name, shellfile)
 
-                jt.remoteCommand = job_path
-                jt.outputPath = ":" + stdout_path
-                jt.errorPath = ":" + stderr_path
-
-                os.chmod(job_path, stat.S_IRWXG | stat.S_IRWXU)
+                jt, stdout_path, stderr_path = setDrmaaJobPaths(jt, job_path)
 
                 job_id = session.runJob(jt)
+
                 job_ids.append(job_id)
                 filenames.append((job_path, stdout_path, stderr_path))
 
                 E.debug("job has been submitted with job_id %s" % str(job_id))
 
             E.debug("waiting for %i jobs to finish " % len(job_ids))
+
             session.synchronize(job_ids, drmaa.Session.TIMEOUT_WAIT_FOREVER,
                                 False)
 
@@ -698,7 +478,7 @@ def run(**kwargs):
             for job_id, statement, paths in zip(job_ids, statement_list,
                                                 filenames):
                 job_path, stdout_path, stderr_path = paths
-                _collectSingleJobFromCluster(session, job_id,
+                collectSingleJobFromCluster(session, job_id,
                                              statement,
                                              stdout_path,
                                              stderr_path,
@@ -716,17 +496,11 @@ def run(**kwargs):
             if options.get("dryrun", False):
                 return
 
-            job_path, stdout_path, stderr_path = buildJobScript(statement,
-                                                                job_memory,
-                                                                job_name)
+            jt = setupDrmaaJobTemplate(session, options, job_name, job_memory)
+            E.debug("Job spec is: %s" % jt.nativeSpecification)
 
-            jt = setupJob(session, options, job_memory, job_name)
-
-            jt.remoteCommand = job_path
-            # later: allow redirection of stdout and stderr to files;
-            # can even be across hosts?
-            jt.outputPath = ":" + stdout_path
-            jt.errorPath = ":" + stderr_path
+            job_path = _writeJobScript(statement, job_memory, job_name, shellfile)
+            jt, stdout_path, stderr_path = setDrmaaJobPaths(jt, job_path)
 
             if "job_array" in options and options["job_array"] is not None:
                 # run an array job
@@ -747,7 +521,7 @@ def run(**kwargs):
                 job_id = session.runJob(jt)
                 E.debug("job has been submitted with job_id %s" % str(job_id))
 
-                _collectSingleJobFromCluster(session, job_id,
+                collectSingleJobFromCluster(session, job_id,
                                              statement,
                                              stdout_path,
                                              stderr_path,

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -111,6 +111,9 @@ HARDCODED_PARAMS = {
                 --cluster-queue=%(cluster_queue)s
                 --cluster-num-jobs=%(cluster_num_jobs)i
                 --cluster-priority=%(cluster_priority)i
+                --cluster-queue-manager=%(cluster_queue_manager)s
+                --cluster-memory-resource=%(cluster_memory_resource)s
+                --cluster-memory-default=%(cluster_memory_default)s
     """,
     # command to get tab-separated output from database
     'cmd-sql': """sqlite3 -header -csv -separator $'\\t' """,
@@ -136,7 +139,7 @@ HARDCODED_PARAMS = {
     # directory used for temporary files shared across machines
     'shared_tmpdir': os.environ.get("SHARED_TMPDIR", "/ifs/scratch"),
     # queue manager (supported: sge, slurm)
-    'queue_manager': 'sge',
+    'cluster_queue_manager': 'sge',
     # cluster queue to use
     'cluster_queue': 'all.q',
     # priority of jobs in cluster queue
@@ -309,8 +312,7 @@ def getParameters(filenames=["pipeline.ini", ],
         TriggeredDefaultFactory.with_default = True
 
     if site_ini:
-        # SNS: I propose that all hardcoded PARAMs be moved to here
-        # read configuration from /etc
+        # read configuration from /etc/cgat/pipeline.ini
         fn = "/etc/cgat/pipeline.ini"
         if os.path.exists(fn):
             filenames.insert(0, fn)

--- a/CGATPipelines/Pipeline/__init__.py
+++ b/CGATPipelines/Pipeline/__init__.py
@@ -220,9 +220,11 @@ from CGATPipelines.Pipeline.Control import *
 from CGATPipelines.Pipeline.Database import *
 from CGATPipelines.Pipeline.Local import *
 from CGATPipelines.Pipeline.Files import *
+from CGATPipelines.Pipeline.Cluster import *
 from CGATPipelines.Pipeline.Execution import *
 from CGATPipelines.Pipeline.Utils import *
 from CGATPipelines.Pipeline.Parameters import *
+
 
 from CGAT import Experiment as E
 

--- a/scripts/farm.py
+++ b/scripts/farm.py
@@ -643,25 +643,8 @@ def hasFinished(retcode, filename, output_tag, logfile):
 def runDRMAA(data, environment):
     '''run jobs in data using drmaa to connect to the cluster.'''
 
-    # SNS: the function P.writeDrmaaJobScript detects errors
-    #      by default
-    #
-    # prefix to detect errors within pipes
-    # prefix = '''detect_pipe_error_helper()
-    # {
-    # while [ "$#" != 0 ] ; do
-    #     # there was an error in at least one program of the pipe
-    #     if [ "$1" != 0 ] ; then return 1 ; fi
-    #     shift 1
-    # done
-    # return 0
-    # }
-    # detect_pipe_error() {
-    # detect_pipe_error_helper "${PIPESTATUS[@]}"
-    # return $?
-    # }
-    # '''
-    # suffix = "; detect_pipe_error"
+    # SNS: Error dection now taken care of with Cluster.py
+    # expandStatement function
 
     # working directory - needs to be the one from which the
     # the script is called to resolve input files.
@@ -669,8 +652,6 @@ def runDRMAA(data, environment):
 
     session = drmaa.Session()
     session.initialize()
-
-    # jt = session.createJobTemplate()
 
     jobids = []
     kwargs = {}
@@ -739,20 +720,8 @@ def runDRMAA(data, environment):
                         "could not export environment variable '%s'" % en)
         jt.jobEnvironment = e
 
-        # SNS: Now taken care of by P.setupDrmaaJobTemplate()
-        # jt.args = []
-        # o = ["-V",
-        #       "-N %s" % os.path.basename(kwargs.get("outfile", "farm.py"))]
-        # if options.cluster_queue:
-        #     o.append("-q %s" % options.cluster_queue)
-        # if options.cluster_priority:
-        #     o.append("-p %i" % options.cluster_priority)
-        # if options.cluster_options:
-        #    o.append(options.cluster_options)
-        # jt.nativeSpecification = " ".join(o)
-
-        # keep stdout and stderr separate
-        # jt.joinFiles = False
+        # SNS: Native specifation setting abstracted
+        # to Pipeline/Cluster.setupDrmaaJobTemplate()
 
         # use stdin for data
         if from_stdin:


### PR DESCRIPTION
Further refactoring to make the code base queue-manager agnostic.
- Refactoring is needed to allow a common DRMAA abstraction for both the Pipeline module and farm.py. The abstracted functions are in the Pipeline/Cluster.py module so that they can be imported into farm.py. If preferred they could go into Pipeline/Utils.py or elsewhere.
- farm.py cluster parameters still come from CGAT/Experiment.py to which extra cluster parameters (inc cluster_queue_manager) have been added (see corresponding pull request). The cmd-farm parameter is correspondingly updated in Pipeline/Parameters.py.
- A new --job-memory option is added to farm.py for setting the required memory in the absence of --cluster-memory-default (which is now the default for cmd-farm jobs). Note that setupDrmaaJobTemplate() in Pipeline/Cluster.py requires job_memory to be set. Currently the default of --job-memory in farm.py is "None" which means that in the absence of --cluster-memory-default farm.py DRMAA jobs will fail to run. I suggest that somebody recommends a sensible default. (I think it is a good idea for all DRMAA jobs to specify their memory requirements...).
