### PR TITLE
changed macs call from macs14 to macs in runMACS

### DIFF
--- a/CGATPipelines/PipelinePeakcalling.py
+++ b/CGATPipelines/PipelinePeakcalling.py
@@ -834,7 +834,7 @@ def runMACS(infile, outfile,
     statement = '''
     cd %(dir)s;
     checkpoint;
-    macs14
+    macs
     -t %(infile)s
     --diag
     --verbose=10


### PR DESCRIPTION
The command wasnt running  with macs14 as macs is the commandline shortcut  
