### PR TITLE
Add hardcoded 'local_tmpdir' to work around issue #174

### DIFF
--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -134,8 +134,17 @@ HARDCODED_PARAMS = {
     'database_port': 3306,
     # wrapper around non-CGAT scripts
     'cmd-run': """%(pipeline_scriptsdir)s/run.py""",
-    # directory used for temporary local files
+    # legacy directory used for temporary local files
+    #     Use of this var is not recommended
+    #     and will be depreciated
     'tmpdir': os.environ.get("TMPDIR", '/scratch'),
+    # directory used for temporary local tempory files on compute nodes
+    # *** passed directly to the shell      ***
+    # *** may not exist on login/head nodes ***
+    # default matches 'tmpdir' only for backwards compatibility
+    # typically a shell environment var is expected, e.g.
+    # 'local_tmpdir': '$SCRATCH_DIR',
+    'local_tmpdir': os.environ.get("TMPDIR", '/scratch'),
     # directory used for temporary files shared across machines
     'shared_tmpdir': os.environ.get("SHARED_TMPDIR", "/ifs/scratch"),
     # queue manager (supported: sge, slurm)

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -135,8 +135,8 @@ HARDCODED_PARAMS = {
     # wrapper around non-CGAT scripts
     'cmd-run': """%(pipeline_scriptsdir)s/run.py""",
     # legacy directory used for temporary local files
-    #     Use of this var is not recommended
-    #     and will be depreciated
+    #     Use of this var can be problematic (issue #174)
+    #     - it may be depreciated.
     'tmpdir': os.environ.get("TMPDIR", '/scratch'),
     # directory used for temporary local tempory files on compute nodes
     # *** passed directly to the shell      ***


### PR DESCRIPTION
See issue #174.

The key new use case supported with this commit is that PARAMS["local_tmpdir"] can contain the name of a shell environment variable so that cluster queue managers such as SLURM are able to manage scratch space in prolog and epilog scripts.
