### PR TITLE
corrects auto-removal of adapters with trimmomatic

### DIFF
--- a/CGATPipelines/PipelinePreprocess.py
+++ b/CGATPipelines/PipelinePreprocess.py
@@ -78,8 +78,8 @@ def makeAdaptorFasta(infile, outfile, track, dbh, contaminants_file):
     for t in tracks:
         table = PipelineTracks.AutoSample(os.path.basename(t)).asTable()
 
-        query = "SELECT Possible_Source, Sequence FROM "
-        "%s_fastqc_Overrepresented_sequences;" % table
+        query = '''SELECT Possible_Source, Sequence FROM
+        %s_fastqc_Overrepresented_sequences;''' % table
 
         cc = dbh.cursor()
         try:

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -258,12 +258,6 @@ if PARAMS.get("preprocessors", None):
         '''process reads from .fastq and other sequence files.
         '''
         trimmomatic_options = PARAMS["trimmomatic_options"]
-        if PARAMS["trimmomatic_adapter"]:
-            trimmomatic_options = " ILLUMINACLIP:%s:%s:%s:%s " % (
-                PARAMS["trimmomatic_adapter"],
-                PARAMS["trimmomatic_mismatches"],
-                PARAMS["trimmomatic_p_thresh"],
-                PARAMS["trimmomatic_c_thresh"]) + trimmomatic_options
 
         if PARAMS["auto_remove"]:
             trimmomatic_options = " ILLUMINACLIP:%s:%s:%s:%s " % (
@@ -271,6 +265,14 @@ if PARAMS.get("preprocessors", None):
                 PARAMS["trimmomatic_mismatches"],
                 PARAMS["trimmomatic_p_thresh"],
                 PARAMS["trimmomatic_c_thresh"]) + trimmomatic_options
+
+        else:
+            if PARAMS["trimmomatic_adapter"]:
+                trimmomatic_options = " ILLUMINACLIP:%s:%s:%s:%s " % (
+                    PARAMS["trimmomatic_adapter"],
+                    PARAMS["trimmomatic_mismatches"],
+                    PARAMS["trimmomatic_p_thresh"],
+                    PARAMS["trimmomatic_c_thresh"]) + trimmomatic_options
 
         job_threads = PARAMS["threads"]
         job_memory = "7G"


### PR DESCRIPTION
The pipeline.ini for readqc states:
"# if adapter removal is required, specify the location of a fasta file
# containing adapters and define the adapter parameters
# this variable will be overriden if auto_remove != 0

adapter=/ifs/apps/bio/trimmomatic-0.32/adapters/TruSeq2-PE.fa"

In fact, both the adapter fasta and "auto-detect" fasta were being supplied consecutively. This is not the expected behavior according to the ini and can lead to java array errors with trimmomatic which expects reads to be similar lengths for adapter processing.

Commit rectifies this.
