### PR TITLE
Pipeline Mapping: Picard RNASeqMetrics & related changes

### DIFF
--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -2229,15 +2229,14 @@ class Hisat(Mapper):
     # hisat can work of compressed files
     compress = True
 
-    executable = "tophat"
+    executable = "hisat"
 
     def __init__(self, remove_non_unique=False, strip_sequence=False,
-                 strandedness=True, *args, **kwargs):
+                 *args, **kwargs):
         Mapper.__init__(self, *args, **kwargs)
 
         self.remove_non_unique = remove_non_unique
         self.strip_sequence = strip_sequence
-        self.strandedness = strandedness
 
     def mapper(self, infiles, outfile):
         '''
@@ -2270,15 +2269,9 @@ class Hisat(Mapper):
         executable = self.executable
 
         num_files = [len(x) for x in infiles]
-        if self.strandedness and not (self.strandedness in
-                                      ['unstranded', 'fr-unstranded']):
-            stranded_option = '--rna-strandness %%(hisat_library_type)s'
-        else:
-            stranded_option = ""
         if max(num_files) != min(num_files):
             raise ValueError(
                 "mixing single and paired-ended data not possible.")
-
         nfiles = max(num_files)
 
         tmpdir_hisat = os.path.join(self.tmpdir_fastq + "hisat")
@@ -2294,7 +2287,7 @@ class Hisat(Mapper):
             mkdir %(tmpdir_hisat)s;
             %(executable)s
             --threads %%(hisat_threads)i
-            %(stranded_option)s
+            --rna-strandness %%(hisat_library_type)s
             %%(hisat_options)s
             -x %(index_prefix)s
             -U %(infiles)s

--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -2272,7 +2272,7 @@ class Hisat(Mapper):
         num_files = [len(x) for x in infiles]
         if self.strandedness and not (self.strandedness in
                                       ['unstranded', 'fr-unstranded']):
-            stranded_option = '--rna-strandness %(hisat_library_type)s'
+            stranded_option = '--rna-strandness %%(hisat_library_type)s'
         else:
             stranded_option = ""
         if max(num_files) != min(num_files):

--- a/CGATPipelines/PipelineMappingQC.py
+++ b/CGATPipelines/PipelineMappingQC.py
@@ -645,7 +645,7 @@ def loadBAMStats(infiles, outfile):
         P.run()
 
 
-def buildPicardRnaSeqMetrics(infiles, outfile):
+def buildPicardRnaSeqMetrics(infiles, strand, outfile):
     '''run picard:RNASeqMetrics
 
     
@@ -676,7 +676,7 @@ def buildPicardRnaSeqMetrics(infiles, outfile):
     INPUT=%(infile)s
     ASSUME_SORTED=true
     OUTPUT=%(outfile)s
-    STRAND=SECOND_READ_TRANSCRIPTION_STRAND
+    STRAND=%(strand)s
     VALIDATION_STRINGENCY=SILENT
     '''
     P.run()

--- a/CGATPipelines/PipelineMappingQC.py
+++ b/CGATPipelines/PipelineMappingQC.py
@@ -643,3 +643,64 @@ def loadBAMStats(infiles, outfile):
         | %(load_statement)s
         >> %(outfile)s """
         P.run()
+
+
+def buildPicardRnaSeqMetrics(infiles, outfile):
+    '''run picard:RNASeqMetrics
+
+    
+
+    Arguments
+    ---------
+    infiles : string
+        Input filename in :term:`BAM` format.
+    outfile : string
+        Output filename with picard output.
+
+    '''
+    job_memory = PICARD_MEMORY
+    job_threads = 3
+    infile, genome = infiles
+
+    if BamTools.getNumReads(infile) == 0:
+        E.warn("no reads in %s - no metrics" % infile)
+        P.touch(outfile)
+        return
+
+    os.environ["CGAT_JAVA_OPTS"] = "-Xmx%s -XX:+UseParNewGC\
+                                    -XX:+UseConcMarkSweepGC" % (PICARD_MEMORY)
+    statement = '''CollectRnaSeqMetrics
+    REF_FLAT=%(genome)s
+    INPUT=%(infile)s
+    ASSUME_SORTED=true
+    OUTPUT=%(outfile)s
+    STRAND=SECOND_READ_TRANSCRIPTION_STRAND
+    VALIDATION_STRINGENCY=SILENT
+    '''
+    P.run()
+    os.unsetenv("CGAT_JAVA_OPTS")
+
+
+def loadPicardRnaSeqMetrics(infiles, outfile):
+    '''load picard rna stats into database.
+
+    Loads table into the database
+       * picard_rna_metrics
+
+    Arguments
+    ---------
+    infile : string
+        Filenames of files with picard metric information. Each file
+        corresponds to a different track.
+    outfile : string
+        Logfile. The table name will be derived from `outfile`.
+    '''
+
+    suffix = "picard_rna_metrics"
+
+    # the loading functions expect "infile_name.pipeline_suffix" as the infile
+    # names.
+    infile_names = [x[:-len("." + suffix)] for x in infiles]
+
+    loadPicardMetrics(infile_names, outfile, suffix, "",
+                      tablename="picard_rna_metrics")

--- a/CGATPipelines/pipeline_docs/pipeline_mapping/pipeline.rst
+++ b/CGATPipelines/pipeline_docs/pipeline_mapping/pipeline.rst
@@ -8,6 +8,7 @@
    pipeline/MappingContext.rst
    pipeline/MappingAlignmentStatistics.rst
    pipeline/MappingComplexity.rst
+   pipeline/MappingRNA.rst
    pipeline/ReferenceCoverage.rst
 
 .. need to sort out variables. Need to be in conf.py

--- a/CGATPipelines/pipeline_docs/pipeline_mapping/pipeline/MappingRNA.rst
+++ b/CGATPipelines/pipeline_docs/pipeline_mapping/pipeline/MappingRNA.rst
@@ -23,6 +23,7 @@ The y axis represents the relative coverage of that part of a transcript.
    :yrange: 0,
    :xrange: 0,100
    :ytitle: read coverage
+   :xtitle: 5' position 3'
 
    Individual plots
 
@@ -33,7 +34,7 @@ The y axis represents the relative coverage of that part of a transcript.
    :yrange: 0,
    :groupby: track
    :ytitle: read coverage
-   :xtitle: 
+   :xtitle: 5' position 3'
    :layout: column-3
    :width: 200
 

--- a/CGATPipelines/pipeline_docs/pipeline_mapping/pipeline/MappingRNA.rst
+++ b/CGATPipelines/pipeline_docs/pipeline_mapping/pipeline/MappingRNA.rst
@@ -1,0 +1,41 @@
+=====================
+Picard RNASeq Metrics
+=====================
+
+This section looks at the output from the Picard RNASeqMetrics.
+If in doubt please check for the presence of a histogram in the ".....picard_rna_metrics" file(s) in the bam directory. 
+
+Picard CollectRnaSeq metrics for each BAM file for each :term:`track`. See the 
+`Picard metrics <http://picard.sourceforge.net/picard-metric-definitions.shtml#CollectRnaSeqMetrics>`_
+for a definition of the field contents.
+
+Data table
+
+.. report:: Mapping.PicardRnaMetrics
+   :render: table
+
+All histograms. In the plot the X axis the relative position in the transcript, where 0 is the 5' end and 100 represents the 3' end.
+The y axis represents the relative coverage of that part of a transcript.
+
+.. report:: Mapping.RnaBiasTable
+   :render: line-plot
+   :as-lines:
+   :yrange: 0,
+   :xrange: 0,100
+   :ytitle: read coverage
+
+   Individual plots
+
+.. report:: Mapping.RnaBiasTable
+   :render: line-plot
+   :as-lines:
+   :xrange: 0,100
+   :yrange: 0,
+   :groupby: track
+   :ytitle: read coverage
+   :xtitle: 
+   :layout: column-3
+   :width: 200
+
+   Grouped plots
+

--- a/CGATPipelines/pipeline_docs/pipeline_mapping/trackers/Mapping.py
+++ b/CGATPipelines/pipeline_docs/pipeline_mapping/trackers/Mapping.py
@@ -32,6 +32,9 @@ class PicardSummary(MappingTracker, SingleTableTrackerRows):
 class PicardDuplicationSummary(MappingTracker, SingleTableTrackerRows):
     table = "picard_duplication_metrics"
 
+class PicardRnaMetrics(MappingTracker, SingleTableTrackerRows):
+    table = "picard_rna_metrics"
+
 
 class PicardAlignmentSummaryMetrics(MappingTracker, SingleTableTrackerRows):
     table = "picard_stats_alignment_summary_metrics"
@@ -81,6 +84,11 @@ class DuplicationMetricsTable(MappingTracker, SingleTableTrackerHistogram):
         data = self.getAll(
             "SELECT %(fields)s FROM %(table)s ORDER BY coverage_multiple")
         return data
+
+class RnaBiasTable(MappingTracker, SingleTableTrackerHistogram):
+
+    table = "picard_rna_histogram"
+    column = "coverage_multiple"
 
 
 class MappingFlagsMismatches(MappingTracker, SingleTableTrackerHistogram):

--- a/CGATPipelines/pipeline_docs/pipeline_mapping/trackers/Mapping.py
+++ b/CGATPipelines/pipeline_docs/pipeline_mapping/trackers/Mapping.py
@@ -32,6 +32,7 @@ class PicardSummary(MappingTracker, SingleTableTrackerRows):
 class PicardDuplicationSummary(MappingTracker, SingleTableTrackerRows):
     table = "picard_duplication_metrics"
 
+
 class PicardRnaMetrics(MappingTracker, SingleTableTrackerRows):
     table = "picard_rna_metrics"
 
@@ -84,6 +85,7 @@ class DuplicationMetricsTable(MappingTracker, SingleTableTrackerHistogram):
         data = self.getAll(
             "SELECT %(fields)s FROM %(table)s ORDER BY coverage_multiple")
         return data
+
 
 class RnaBiasTable(MappingTracker, SingleTableTrackerHistogram):
 

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -386,12 +386,15 @@ def buildRefFlat(infile, outfile):
     '''build flat geneset for Picard RnaSeqMetrics.
     '''
 
+    tmpflat = P.getTempFilename(".")
+
     statement = ''' 
-    gtfToGenePred -genePredExt -geneNameAsName2 %(infile)s refFlat.tmp.txt;
-    paste <(cut -f 12 refFlat.tmp.txt) <(cut -f 1-10 refFlat.tmp.txt)
+    gtfToGenePred -genePredExt -geneNameAsName2 %(infile)s %(tmpflat)s;
+    paste <(cut -f 12 %(tmpflat)s) <(cut -f 1-10 %(tmpflat)s)
     > %(outfile)s
     '''
     P.run()
+    os.unlink(tmpflat)
 
 
 @active_if(SPLICED_MAPPING)

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -388,7 +388,7 @@ def buildRefFlat(infile, outfile):
 
     tmpflat = P.getTempFilename(".")
 
-    statement = ''' 
+    statement = '''
     gtfToGenePred -genePredExt -geneNameAsName2 %(infile)s %(tmpflat)s;
     paste <(cut -f 12 %(tmpflat)s) <(cut -f 1-10 %(tmpflat)s)
     > %(outfile)s
@@ -954,8 +954,7 @@ def mapReadsWithTophat2(infiles, outfile):
         strip_sequence=PARAMS["strip_sequence"])
 
     infile, reffile, transcriptfile = infiles
-    tophat2_options = PARAMS["tophat2_options"] + "--raw-juncs %(reffile)s
-                                                   --" % locals()
+    tophat2_options = PARAMS["tophat2_options"] + "--raw-juncs %(reffile)" % locals()
 
     # Nick - added the option to map to the reference transcriptome first
     # (built within the pipeline)
@@ -2157,7 +2156,7 @@ def loadExonValidation(infiles, outfile):
            r"\1.transcript_counts.tsv.gz")
 def buildTranscriptLevelReadCounts(infiles, outfile):
     '''count reads in gene models
-    
+
     Count the reads from a :term:`bam` file which overlap the
     positions of protein coding transcripts in a :term:`gtf` format
     transcripts file.

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -787,10 +787,11 @@ def mapReadsWithTophat(infiles, outfile):
         :term:`PARAMS`
         path to tophat executable
 
-    tophat_library_type
+    strandness
         :term:`PARAMS`
-        fr-unstranded, fr-firststrand or fr-secondstrand see
-        https://ccb.jhu.edu/software/tophat/manual.shtml#toph
+        FR, RF, F or R or empty see
+        http://www.ccb.jhu.edu/software/hisat/manual.shtml#options
+        will be converted to tophat specific option
 
     tophat_include_reference_transcriptome: bool
         :term:`PARAMS`
@@ -819,6 +820,14 @@ def mapReadsWithTophat(infiles, outfile):
     """
 
     job_threads = PARAMS["tophat_threads"]
+
+    # convert strandness to tophat-style library type
+    if PARAMS["strandness"] == ("RF" or "R"):
+        tophat_library_type = "fr-firststrand"
+    elif PARAMS["strandness"] == ("FR" or "F"):
+        tophat_library_type = "fr-secondstrand"
+    else:
+        tophat_library_type = ""
 
     if "--butterfly-search" in PARAMS["tophat_options"]:
         # for butterfly search - require insane amount of
@@ -888,10 +897,11 @@ def mapReadsWithTophat2(infiles, outfile):
         :term:`PARAMS`
         path to tophat2 executable
 
-    tophat2_library_type
+    strandness
         :term:`PARAMS`
-        fr-unstranded, fr-firststrand or fr-secondstrand see
-        https://ccb.jhu.edu/software/tophat/manual.shtml#toph
+        FR, RF, F or R or empty see
+        http://www.ccb.jhu.edu/software/hisat/manual.shtml#options
+        will be converted to tophat specific option
 
     tophat2_include_reference_transcriptome: bool
         :term:`PARAMS`
@@ -924,6 +934,14 @@ def mapReadsWithTophat2(infiles, outfile):
     '''
     job_threads = PARAMS["tophat2_threads"]
 
+    # convert strandness to tophat-style library type
+    if PARAMS["strandness"] == ("RF" or "R"):
+        tophat2_library_type = "fr-firststrand"
+    elif PARAMS["strandness"] == ("FR" or "F"):
+        tophat2_library_type = "fr-secondstrand"
+    else:
+        tophat2_library_type = "fr-unstranded"
+
     if "--butterfly-search" in PARAMS["tophat2_options"]:
         # for butterfly search - require insane amount of
         # RAM.
@@ -936,7 +954,8 @@ def mapReadsWithTophat2(infiles, outfile):
         strip_sequence=PARAMS["strip_sequence"])
 
     infile, reffile, transcriptfile = infiles
-    tophat2_options = PARAMS["tophat2_options"] + " --raw-juncs %(reffile)s " % locals()
+    tophat2_options = PARAMS["tophat2_options"] + "--raw-juncs %(reffile)s
+                                                   --" % locals()
 
     # Nick - added the option to map to the reference transcriptome first
     # (built within the pipeline)
@@ -988,7 +1007,7 @@ def mapReadsWithHisat(infiles, outfile):
         :term:`PARAMS`
         path to hisat executable
 
-    hisat_library_type: str
+    strandness: str
         :term:`PARAMS`
         hisat rna-strandess parameter, see
         https://ccb.jhu.edu/software/hisat/manual.shtml#command-line
@@ -1019,6 +1038,7 @@ def mapReadsWithHisat(infiles, outfile):
 
     job_threads = PARAMS["hisat_threads"]
     job_memory = PARAMS["hisat_memory"]
+    hisat_library_type = PARAMS["strandness"]
 
     m = PipelineMapping.Hisat(
         executable=P.substituteParameters(**locals())["hisat_executable"],

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -827,7 +827,7 @@ def mapReadsWithTophat(infiles, outfile):
     elif PARAMS["strandness"] == ("FR" or "F"):
         tophat_library_type = "fr-secondstrand"
     else:
-        tophat_library_type = ""
+        tophat_library_type = "fr-unstranded"
 
     if "--butterfly-search" in PARAMS["tophat_options"]:
         # for butterfly search - require insane amount of

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -1952,7 +1952,8 @@ def buildPicardRnaSeqMetrics(infiles, outfile):
 
 @P.add_doc(PipelineMappingQC.loadPicardRnaSeqMetrics)
 @jobs_limit(PARAMS.get("jobs_limit_db", 1), "db")
-@merge(buildPicardRnaSeqMetrics, ["picard_rna_metrics.load"])
+@merge(buildPicardRnaSeqMetrics, ["picard_rna_metrics.load",
+                                  "picard_rna_histogram.load"])
 def loadPicardRnaSeqMetrics(infiles, outfiles):
     '''merge alignment stats into single tables.'''
     # separate load function while testing

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -1970,7 +1970,14 @@ def loadPicardDuplicationStats(infiles, outfiles):
            ".picard_rna_metrics")
 def buildPicardRnaSeqMetrics(infiles, outfile):
     '''Get duplicate stats from picard RNASeqMetrics '''
-    PipelineMappingQC.buildPicardRnaSeqMetrics(infiles, outfile)
+    # convert strandness to tophat-style library type
+    if PARAMS["strandness"] == ("RF" or "R"):
+        strand = "SECOND_READ_TRANSCRIPTION_STRAND"
+    elif PARAMS["strandness"] == ("FR" or "F"):
+        strand = "FIRST_READ_TRANSCRIPTION_STRAND"
+    else:
+        strand = "NONE"
+    PipelineMappingQC.buildPicardRnaSeqMetrics(infiles, strand, outfile)
 
 
 @P.add_doc(PipelineMappingQC.loadPicardRnaSeqMetrics)
@@ -1979,7 +1986,6 @@ def buildPicardRnaSeqMetrics(infiles, outfile):
                                   "picard_rna_histogram.load"])
 def loadPicardRnaSeqMetrics(infiles, outfiles):
     '''merge alignment stats into single tables.'''
-    # separate load function while testing
     PipelineMappingQC.loadPicardRnaSeqMetrics(infiles, outfiles)
 
 

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -954,7 +954,8 @@ def mapReadsWithTophat2(infiles, outfile):
         strip_sequence=PARAMS["strip_sequence"])
 
     infile, reffile, transcriptfile = infiles
-    tophat2_options = PARAMS["tophat2_options"] + "--raw-juncs %(reffile)" % locals()
+    tophat2_options = PARAMS["tophat2_options"] + \
+        " --raw-juncs %(reffile)s" % locals()
 
     # Nick - added the option to map to the reference transcriptome first
     # (built within the pipeline)

--- a/CGATPipelines/pipeline_mapping/pipeline.ini
+++ b/CGATPipelines/pipeline_mapping/pipeline.ini
@@ -39,7 +39,22 @@ max_intron_size=2000000
 # hisat  
 # (bfast)
 # (shrimp)
-mappers=bwa,tophat2,star
+mappers=?!
+
+# Strand Assignment for spliced mapping
+# Using HISAT nomenclature, more detail available at
+# http://www.ccb.jhu.edu/software/hisat/manual.shtml#options
+# under --rna-strandness
+# FR = secondstrand paired-end
+# RF = firststrand paired-end
+# F = secondstrand single-end
+# R = firststrand single-end
+# 
+# Paired-end sequencinng after TruSeq Library Prep is "RF"
+#
+# Default = empty: unstranded
+# Required for all spliced alignment
+strandness=
 
 # Strip read sequence and quality information.
 # Saves space for rnaseq and chipseq runs, but 
@@ -139,16 +154,11 @@ memory=1.9G
 
 # --mate-inner-dist parameter for tophat, required for paired-ended runs.
 # inner distance (in TopHat) = insert length - 2 * read length
-# also: tophat2
 mate_inner_dist=60
 
 # map to reference transcriptome
-# also: tophat2
 include_reference_transcriptome=1
 
-# library type (see tophat/cufflinks manual) - also used by cufflinks and cuffdiff
-# also: tophat2
-library_type=fr-unstranded
 
 ################################################################
 ################################################################
@@ -181,16 +191,11 @@ memory=3.9G
 
 # --mate-inner-dist parameter for tophat, required for paired-ended runs.
 # inner distance (in TopHat) = insert length - 2 * read length
-# also: tophat2
 mate_inner_dist=60
 
 # map to reference transcriptome
-# also: tophat2
 include_reference_transcriptome=1
 
-# library type (see tophat/cufflinks manual) - also used by cufflinks and cuffdiff
-# also: tophat2
-library_type=fr-unstranded
 
 ################################################################
 ################################################################
@@ -211,9 +216,6 @@ threads=12
 # memory required for hisat jobs - note that this is multiplied by the
 # number of threads. Thus, 4 threads * 2G = 8G
 memory=3.9G
-
-# library type (see hisat manual) - also used by cufflinks and cuffdiff
-library_type=fr-unstranded
 
 # directory containing hisat indexes for genomes
 index_dir=

--- a/CGATPipelines/pipeline_mapping/pipeline.ini
+++ b/CGATPipelines/pipeline_mapping/pipeline.ini
@@ -39,7 +39,7 @@ max_intron_size=2000000
 # hisat  
 # (bfast)
 # (shrimp)
-mappers=?!
+mappers=bwa,tophat2,star
 
 # Strand Assignment for spliced mapping
 # Using HISAT nomenclature, more detail available at


### PR DESCRIPTION
Contains the following improvement (Issue #191)
- Picard RnaSeqMetrics added, loaded to csvdb, only run with splice aware mappers
- Specifically formatted "refFlat" genome annotations produced for picard
- Above included in CGATReport
- Single Strandedness variable now present in general options
- cleaned up hisat parameter
