### PR TITLE
Add jobs options to cluster options rather than replacing

### DIFF
--- a/CGATPipelines/Pipeline/Execution.py
+++ b/CGATPipelines/Pipeline/Execution.py
@@ -368,8 +368,8 @@ def run(**kwargs):
     options.update(kwargs.items())
 
     # insert a few legacy synonyms
-    options['cluster_options'] = options.get('job_options',
-                                             options['cluster_options'])
+    options['cluster_options'] += " " + options.get('job_options',
+                                                    "")
     options['cluster_queue'] = options.get('job_queue',
                                            options['cluster_queue'])
     options['without_cluster'] = options.get('without_cluster')


### PR DESCRIPTION
Previously P.run chceked if job options were set, and if they are, overwrites cluster_options with them. 
This brakes the ability to set cluster_options in the `.cgat` file. This PR changes the logic so that local job_options are added to cluster_options rather than overwritting them.

**As this PR changes existing logic i'd appreciate a second opinion on the suitability.** 
