### PR TITLE
Ts py3 syntax errors

### DIFF
--- a/CGATPipelines/Pipeline/Cluster.py
+++ b/CGATPipelines/Pipeline/Cluster.py
@@ -35,6 +35,7 @@ Reference
 import re
 import os
 import stat
+import time
 import CGAT.Experiment as E
 try:
     import drmaa
@@ -168,14 +169,14 @@ def setupDrmaaJobTemplate(drmaa_session, options, job_name, job_memory):
         # PBS Pro docs
         # http://www.pbsworks.com/PBSProduct.aspx?n=PBS-Professional&c=Overview-and-Capabilities
         # http://technion.ac.il/usg/tamnun/PBSProUserGuide12.1.pdf
-	
-	# DRMAA for PBS Pro is the same as for torque:
+
+        # DRMAA for PBS Pro is the same as for torque:
         # http://apps.man.poznan.pl/trac/pbs-drmaa
         # Webpages with some examples:
         # https://wiki.galaxyproject.org/Admin/Config/Performance/Cluster#PBS
         # https://sites.google.com/a/case.edu/hpc-upgraded-cluster/home/Software-Guide/pbs-drmaa
-	# https://albertsk.files.wordpress.com/2011/12/pbs.pdf
-	
+        # https://albertsk.files.wordpress.com/2011/12/pbs.pdf
+
         # PBS Pro has some differences with torque so separating
 
         # Set environment variables in .bashrc:
@@ -184,61 +185,60 @@ def setupDrmaaJobTemplate(drmaa_session, options, job_name, job_memory):
 
         # PBSPro only takes the first 15 characters, throws uninformative error if longer.
         # mem is maximum amount of RAM used by job; mem_free doesn't seem to be available.
-	spec = ["-N %s" % job_name[0:15], 
-		"-l mem=%s" % job_memory]
+        spec = ["-N %s" % job_name[0:15],
+                "-l mem=%s" % job_memory]
 
-	# Leaving walltime to be specified by user as difficult to set dynamically and
-	# depends on site/admin configuration of default values. Likely means setting for 
-	# longest job with trade-off of longer waiting times for resources to be 
-	# available for other jobs. 
+        # Leaving walltime to be specified by user as difficult to set dynamically and
+        # depends on site/admin configuration of default values. Likely means setting for
+        # longest job with trade-off of longer waiting times for resources to be
+        # available for other jobs.
         if options["cluster_options"]:
-	    if "mem" not in options["cluster_options"]:
-	        spec.append("%(cluster_options)s")
-	    elif "mem" in options["cluster_options"]:
-	        spec = ["-N %s" % job_name[0:15]]
+            if "mem" not in options["cluster_options"]:
+                spec.append("%(cluster_options)s")
+            elif "mem" in options["cluster_options"]:
+                spec = ["-N %s" % job_name[0:15]]
                 spec.append("%(cluster_options)s")
 
-
-	# if process has multiple threads, use a parallel environment:
+        # if process has multiple threads, use a parallel environment:
         # TO DO: error in fastqc build_report, var referenced before assignment.
-	# For now adding to workaround:
-	if 'job_threads' in options:
+        # For now adding to workaround:
+        if 'job_threads' in options:
             job_threads = options["job_threads"]
         else:
             job_threads = 1
 
-	multithread = 'job_threads' in options and options['job_threads'] > 1
+        multithread = 'job_threads' in options and options['job_threads'] > 1
         if multithread:
-	   # TO DO 'select=1' determines de number of nodes. Should go in a config file.
-	   # mem is per node and maximum memory
-	   # Site dependent but in general setting '#PBS -l select=NN:ncpus=NN:mem=NN{gb|mb}'
-	   # is sufficient for parallel jobs (OpenMP, MPI).
-	   # Also architecture dependent, jobs could be hanging if resource doesn't exist.
-	   # TO DO: Kill if long waiting time? 
-	    spec = ["-N %s" % job_name[0:15], 
-		    "-l select=1:ncpus=%s:mem=%s" % (job_threads, job_memory)]
-	
-	    if options["cluster_options"]:
-                if "mem" not in options["cluster_options"]:
-                    spec.append("%(cluster_options)s")
-		
-            	elif "mem" in options["cluster_options"]:
-		    raise ValueError('''mem resource specified twice, check ~/.cgat config file, 
-		    		     .ini files, command line options, etc.''')
+            # TO DO 'select=1' determines de number of nodes. Should go in a config file.
+            # mem is per node and maximum memory
+            # Site dependent but in general setting '#PBS -l select=NN:ncpus=NN:mem=NN{gb|mb}'
+            # is sufficient for parallel jobs (OpenMP, MPI).
+            # Also architecture dependent, jobs could be hanging if resource doesn't exist.
+            # TO DO: Kill if long waiting time?
+            spec = ["-N %s" % job_name[0:15],
+                    "-l select=1:ncpus=%s:mem=%s" % (job_threads, job_memory)]
+
+        if options["cluster_options"]:
+            if "mem" not in options["cluster_options"]:
+                spec.append("%(cluster_options)s")
+
+            elif "mem" in options["cluster_options"]:
+                raise ValueError('''mem resource specified twice, check ~/.cgat config file,
+                ini files, command line options, etc.''')
 
         if "cluster_pe_queue" in options and multithread:
             spec.append(
                 "-q %(cluster_pe_queue)s")
         elif options['cluster_queue'] != "NONE":
             spec.append("-q %(cluster_queue)s")
-	# TO DO: sort out in Parameters.py to allow none values for configparser:
-	elif options ['cluster_queue'] == "NONE": 
-	    pass
+            # TO DO: sort out in Parameters.py to allow none values for configparser:
+        elif options['cluster_queue'] == "NONE":
+            pass
 
         # As for torque, there is no equivalent to sge -V option for pbs-drmaa:
         jt.jobEnvironment = os.environ
         jt.jobEnvironment.update({'BASH_ENV': os.path.join(os.environ['HOME'],
-                                                           '.bashrc')})            
+                                                           '.bashrc')})
 
     else:
         raise ValueError("Queue manager %s not supported" % queue_manager)
@@ -333,7 +333,7 @@ def collectSingleJobFromCluster(session, job_id,
         # termination status could not be provided.":
 
         if not msg.message.startswith("code 24"):
-	     raise
+            raise
         retval = None
 
     stdout, stderr = getStdoutStderr(stdout_path, stderr_path)

--- a/CGATPipelines/Pipeline/Control.py
+++ b/CGATPipelines/Pipeline/Control.py
@@ -802,7 +802,6 @@ def main(args=sys.argv):
         variable, value = variables.split("=")
         PARAMS[variable.strip()] = IOTools.str2val(value.strip())
 
-
     if args:
         options.pipeline_action = args[0]
         if len(args) > 1:
@@ -1002,5 +1001,3 @@ def main(args=sys.argv):
                          options.pipeline_action)
 
     E.Stop()
-
-

--- a/CGATPipelines/Pipeline/Execution.py
+++ b/CGATPipelines/Pipeline/Execution.py
@@ -46,6 +46,11 @@ import CGAT.Experiment as E
 import CGAT.IOTools as IOTools
 from CGAT.IOTools import snip as snip
 
+from CGATPipelines.Pipeline.Utils import getCallerLocals
+from CGATPipelines.Pipeline.Parameters import substituteParameters
+from CGATPipelines.Pipeline.Files import getTempFilename, getTempFile
+from CGATPipelines.Pipeline.Cluster import *
+
 # talking to a cluster
 try:
     import drmaa
@@ -55,11 +60,6 @@ except RuntimeError:
 
 # Set from Pipeline.py
 PARAMS = {}
-
-from CGATPipelines.Pipeline.Utils import getCallerLocals
-from CGATPipelines.Pipeline.Parameters import substituteParameters
-from CGATPipelines.Pipeline.Files import getTempFilename, getTempFile
-from CGATPipelines.Pipeline.Cluster import *
 
 # global drmaa session
 GLOBAL_SESSION = None
@@ -285,8 +285,8 @@ def getJobMemory(options=False, PARAMS=False):
     if options and 'job_memory' in options:
         job_memory = options['job_memory']
 
-    elif options and "mem_free" in options["cluster_options"] and \
-        PARAMS.get("cluster_memory_resource", False):
+    elif (options and "mem_free" in options["cluster_options"] and
+          PARAMS.get("cluster_memory_resource", False)):
 
         E.warn("use of mem_free in job options is deprecated, please"
                " set job_memory local var instead")
@@ -479,11 +479,11 @@ def run(**kwargs):
                                                 filenames):
                 job_path, stdout_path, stderr_path = paths
                 collectSingleJobFromCluster(session, job_id,
-                                             statement,
-                                             stdout_path,
-                                             stderr_path,
-                                             job_path,
-                                             ignore_errors=ignore_errors)
+                                            statement,
+                                            stdout_path,
+                                            stderr_path,
+                                            job_path,
+                                            ignore_errors=ignore_errors)
 
             session.deleteJobTemplate(jt)
 
@@ -522,11 +522,11 @@ def run(**kwargs):
                 E.debug("job has been submitted with job_id %s" % str(job_id))
 
                 collectSingleJobFromCluster(session, job_id,
-                                             statement,
-                                             stdout_path,
-                                             stderr_path,
-                                             job_path,
-                                             ignore_errors=ignore_errors)
+                                            statement,
+                                            stdout_path,
+                                            stderr_path,
+                                            job_path,
+                                            ignore_errors=ignore_errors)
 
             session.deleteJobTemplate(jt)
     else:

--- a/CGATPipelines/Pipeline/Files.py
+++ b/CGATPipelines/Pipeline/Files.py
@@ -148,5 +148,3 @@ def checkScripts(filenames):
 
     if missing:
         raise ValueError("missing scripts: %s" % ",".join(missing))
-
-

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -152,7 +152,7 @@ HARDCODED_PARAMS = {
     'shared_tmpdir': os.environ.get("SHARED_TMPDIR", "/ifs/scratch"),
     # queue manager (supported: sge, slurm, torque, pbspro)
     'cluster_queue_manager': 'sge',
-    # cluster queue to use 
+    # cluster queue to use
     'cluster_queue': 'all.q',
     # priority of jobs in cluster queue
     'cluster_priority': -10,

--- a/CGATPipelines/pipeline_liftover.py
+++ b/CGATPipelines/pipeline_liftover.py
@@ -186,27 +186,27 @@ def mergeTranscripts(infile, outfile):
         PARAMS["genome_dir"], PARAMS["%s_genome" % track])
 
     statement = """
-        gunzip < %(infile)s 
-        | awk '/psLayout/ { x = 4; next; } x > 0 { --x; next} { print; }' 
-        | sort -k 14,14 -k 16,16n
-	| %(cmd-farm)s 
-		--split-at-column=14 
-		--output-header 
-		--renumber="%%06i" 
-		--renumber-column=":id" 
-		--log=%(outfile)s.log 
-		--subdirs \
+    gunzip < %(infile)s 
+    | awk '/psLayout/ { x = 4; next; } x > 0 { --x; next} { print; }' 
+    | sort -k 14,14 -k 16,16n
+    | %(cmd-farm)s 
+    --split-at-column=14 
+    --output-header 
+    --renumber="%%06i" 
+    --renumber-column=":id" 
+    --log=%(outfile)s.log 
+    --subdirs \
         "cgat psl2assembly 
                --staggered=all 
                --method=region
                --method=transcript
                 --threshold-merge-distance=0 
                 --threshold-merge-overlap=3
-		--genome=%(genomefile)s
-		--mali-output-format=fasta 
-		--log=%(outfile)s.log 
-		--output-filename-pattern=%%DIR%%%(outfile)s.%%s" 
-	> %(outfile)s"""
+    --genome=%(genomefile)s
+    --mali-output-format=fasta 
+    --log=%(outfile)s.log 
+    --output-filename-pattern=%%DIR%%%(outfile)s.%%s" 
+    > %(outfile)s"""
 
     P.run()
 

--- a/CGATPipelines/pipeline_variants.py
+++ b/CGATPipelines/pipeline_variants.py
@@ -1585,18 +1585,18 @@ def buildMultipleAlignments(infile, outfile):
     to_cluster = True
 
     statement = '''
-	cgat align_transcripts \
-		--gtf-file=%(infile)s \
-		--cds-gtf-file=%(filename_cds)s \
-		--force-map \
-		--verbose=2 \
-		--output-filename-pattern=%(track)s_%%s.fasta \
-		--output-section=final_aa \
-		--output-section=final_na \
-		--output-section=aligned_aa \
-		--output-section=aligned_na \
-		--output-format="plain-fasta" \
-	< %(filename_pep)s > %(outfile)s
+    cgat align_transcripts \
+    --gtf-file=%(infile)s \
+    --cds-gtf-file=%(filename_cds)s \
+    --force-map \
+    --verbose=2 \
+    --output-filename-pattern=%(track)s_%%s.fasta \
+    --output-section=final_aa \
+    --output-section=final_na \
+    --output-section=aligned_aa \
+    --output-section=aligned_na \
+    --output-format="plain-fasta" \
+    < %(filename_pep)s > %(outfile)s
       '''
 
     P.run()
@@ -1613,18 +1613,18 @@ def buildMultipleAlignmentVariantColumns(infile, outfile):
     to_cluster = True
 
     statement = '''
-	cgat malis2mali \
-		--gtf-file=%(infile)s \
-		--cds-gtf-file=%(filename_cds)s \
-		--force-map \
-		--verbose=2 \
-		--output-filename-pattern=%(track)s_%%s.fasta \
-		--output-section=final_aa \
-		--output-section=final_na \
-		--output-section=aligned_aa \
-		--output-section=aligned_na \
-		--output-format="plain-fasta" \
-	< %(filename_pep)s > %(outfile)s
+    cgat malis2mali \
+    --gtf-file=%(infile)s \
+    --cds-gtf-file=%(filename_cds)s \
+    --force-map \
+    --verbose=2 \
+    --output-filename-pattern=%(track)s_%%s.fasta \
+    --output-section=final_aa \
+    --output-section=final_na \
+    --output-section=aligned_aa \
+    --output-section=aligned_na \
+    --output-format="plain-fasta" \
+    < %(filename_pep)s > %(outfile)s
       '''
 
     P.run()


### PR DESCRIPTION
Ignore the branch name reference to syntax errors.

I've just installed CGATPipelines on my new desktop and got the following error when I tried to import a module:

```
>>> import CGATPipelines.PipelineMapping as M
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/FILESERVER5/proteomics/tss38/git_repos/CGATPipelines/CGATPipelines/PipelineMapping.py", line 90, in <module>
    import CGATPipelines.Pipeline as P
  File "/home/FILESERVER5/proteomics/tss38/git_repos/CGATPipelines/CGATPipelines/Pipeline/__init__.py", line 219, in <module>
    from CGATPipelines.Pipeline.Control import *
  File "/home/FILESERVER5/proteomics/tss38/git_repos/CGATPipelines/CGATPipelines/Pipeline/Control.py", line 81, in <module>
    from CGATPipelines.Pipeline.Execution import execute, startSession,\
  File "/home/FILESERVER5/proteomics/tss38/git_repos/CGATPipelines/CGATPipelines/Pipeline/Execution.py", line 62, in <module>
    from CGATPipelines.Pipeline.Cluster import *
  File "/home/FILESERVER5/proteomics/tss38/git_repos/CGATPipelines/CGATPipelines/Pipeline/Cluster.py", line 187
    spec = ["-N %s" % job_name[0:15], 

TabError: inconsistent use of tabs and spaces in indentation
```

It looks like Py3 is stricter than Py2 when it comes to mixed whitespace so I guess that's why this wasn't picked up with the style tests in Travis (py2.7).