### PR TITLE
Detection of cluster job cancellation by the user or scheduler.

### DIFF
--- a/CGATPipelines/Pipeline/Cluster.py
+++ b/CGATPipelines/Pipeline/Cluster.py
@@ -347,6 +347,18 @@ def collectSingleJobFromCluster(session, job_id,
             (retval.exitStatus,
              "".join(stderr), statement))
 
+    if ((retval.hasExited is False or retval.wasAborted is True) and not
+       ignore_errors):
+
+        raise OSError(
+            "-------------------------------------------------\n"
+            "Cluster job was aborted and/or failed to exit:\n"
+            "Job was aborted: %s \n"
+            "Job has exited: %s \n"
+            "(Job may have been cancelled by the user or the scheduler)\n"
+            "----------------------------------------------------------\n" %
+            (retval.wasAborted, retval.hasExited))
+
     try:
         os.unlink(job_path)
     except OSError:

--- a/CGATPipelines/Pipeline/Cluster.py
+++ b/CGATPipelines/Pipeline/Cluster.py
@@ -352,12 +352,12 @@ def collectSingleJobFromCluster(session, job_id,
 
         raise OSError(
             "-------------------------------------------------\n"
-            "Cluster job was aborted and/or failed to exit:\n"
-            "Job was aborted: %s \n"
-            "Job has exited: %s \n"
+            "Cluster job was aborted (%s) and/or failed (%s) "
+            "while running the following statement:\n"
+            "\n%s\n"
             "(Job may have been cancelled by the user or the scheduler)\n"
             "----------------------------------------------------------\n" %
-            (retval.wasAborted, retval.hasExited))
+            (retval.wasAborted, retval.hasExited, statement))
 
     try:
         os.unlink(job_path)

--- a/CGATPipelines/Pipeline/Cluster.py
+++ b/CGATPipelines/Pipeline/Cluster.py
@@ -352,12 +352,12 @@ def collectSingleJobFromCluster(session, job_id,
 
         raise OSError(
             "-------------------------------------------------\n"
-            "Cluster job was aborted (%s) and/or failed (%s) "
+            "Cluster job was aborted (%s) and/or failed to exit (%s) "
             "while running the following statement:\n"
             "\n%s\n"
             "(Job may have been cancelled by the user or the scheduler)\n"
             "----------------------------------------------------------\n" %
-            (retval.wasAborted, retval.hasExited, statement))
+            (retval.wasAborted, not retval.hasExited, statement))
 
     try:
         os.unlink(job_path)


### PR DESCRIPTION
Raise an OSError for cluster jobs returning with "wasAborted"=True or "hasExited"=False.

These variables are part of the standard DRMAA spec (https://media.readthedocs.org/pdf/drmaa-python/latest/drmaa-python.pdf).

This is necessary (at least for SLURM) for detecting instances where the user or the scheduler has canceled the job.