### PR TITLE
 remove CGATReport.only_directives from all conf.py

### DIFF
--- a/CGATPipelines/configuration/conf.py
+++ b/CGATPipelines/configuration/conf.py
@@ -108,7 +108,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.pngmath',
               'sphinx.ext.ifconfig',
               'sphinx.ext.intersphinx',
-              'CGATReport.only_directives',
+              
               'CGATReport.report_directive',
               'sphinx.ext.inheritance_diagram',
               'CGATReport.errors_directive',

--- a/CGATPipelines/metapipeline_medip/conf.py
+++ b/CGATPipelines/metapipeline_medip/conf.py
@@ -108,7 +108,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.pngmath',
               'sphinx.ext.ifconfig',
               'sphinx.ext.intersphinx',
-              'CGATReport.only_directives',
+              
               'CGATReport.report_directive',
               'sphinx.ext.inheritance_diagram',
               'CGATReport.errors_directive',

--- a/CGATPipelines/pipeline_docs/pipeline_transcriptome/conf.py
+++ b/CGATPipelines/pipeline_docs/pipeline_transcriptome/conf.py
@@ -64,7 +64,7 @@ sphinxreport_images=( ( "hires", "hires.png", 200),
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.coverage', 
               'sphinx.ext.pngmath', 'sphinx.ext.ifconfig',
-              'CGATReport.only_directives', 
+               
               'CGATReport.report_directive', 'CGATReport.inheritance_diagram',
               'CGATReport.errors_directive',
               'CGATReport.roles' ]

--- a/CGATPipelines/pipeline_enrichment/conf.py
+++ b/CGATPipelines/pipeline_enrichment/conf.py
@@ -109,7 +109,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.pngmath',
               'sphinx.ext.ifconfig',
               'sphinx.ext.intersphinx',
-              'CGATReport.only_directives',
+              
               'CGATReport.report_directive',
               'sphinx.ext.inheritance_diagram',
               'CGATReport.errors_directive',

--- a/CGATPipelines/pipeline_geneinfo/conf.py
+++ b/CGATPipelines/pipeline_geneinfo/conf.py
@@ -109,7 +109,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.pngmath',
               'sphinx.ext.ifconfig',
               'sphinx.ext.intersphinx',
-              'CGATReport.only_directives',
+              
               'CGATReport.report_directive',
               'sphinx.ext.inheritance_diagram',
               'CGATReport.errors_directive',

--- a/CGATPipelines/pipeline_gwas/conf.py
+++ b/CGATPipelines/pipeline_gwas/conf.py
@@ -109,7 +109,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.pngmath',
               'sphinx.ext.ifconfig',
               'sphinx.ext.intersphinx',
-              'CGATReport.only_directives',
+              
               'CGATReport.report_directive',
               'sphinx.ext.inheritance_diagram',
               'CGATReport.errors_directive',

--- a/CGATPipelines/pipeline_scrnaseqqc/conf.py
+++ b/CGATPipelines/pipeline_scrnaseqqc/conf.py
@@ -109,7 +109,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.pngmath',
               'sphinx.ext.ifconfig',
               'sphinx.ext.intersphinx',
-              'CGATReport.only_directives',
+              
               'CGATReport.report_directive',
               'sphinx.ext.inheritance_diagram',
               'CGATReport.errors_directive',

--- a/CGATPipelines/pipeline_template_data/conf.py
+++ b/CGATPipelines/pipeline_template_data/conf.py
@@ -108,7 +108,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.pngmath',
               'sphinx.ext.ifconfig',
               'sphinx.ext.intersphinx',
-              'CGATReport.only_directives',
+              
               'CGATReport.report_directive',
               'sphinx.ext.inheritance_diagram',
               'CGATReport.errors_directive',


### PR DESCRIPTION

Removes `CGATReport.only_directives` on all `conf.py` files so the latest version of CGATReport works properly.