### PR TITLE
 make the code location non CGAT specific

### DIFF
--- a/CGATPipelines/pipeline_scrnaseqqc.py
+++ b/CGATPipelines/pipeline_scrnaseqqc.py
@@ -166,11 +166,8 @@ else:
     else:
         DATADIR = PARAMS['data']
 
-USER = os.environ['USER']
-base_dir = "/ifs/devel"
-end_dir = "/cgat/scripts"
-PARAMS['cgat_scripts'] = "/".join([base_dir, USER,
-                                   end_dir])
+CODE_LOCATION =  example=os.path.dirname(E.__file__)
+PARAMS['cgat_scripts'] = re.sub(r'CGAT.*', 'scripts', CODE_LOCATION)
 
 # --------------------------------------
 FASTQ_SUFFIXES = ("*.fastq.1.gz",

--- a/CGATPipelines/pipeline_scrnaseqqc.py
+++ b/CGATPipelines/pipeline_scrnaseqqc.py
@@ -166,9 +166,6 @@ else:
     else:
         DATADIR = PARAMS['data']
 
-CODE_LOCATION = os.path.dirname(E.__file__)
-PARAMS['cgat_scripts'] = re.sub(r'CGAT.*', 'scripts', CODE_LOCATION)
-
 # --------------------------------------
 FASTQ_SUFFIXES = ("*.fastq.1.gz",
                   "*.fastq.2.gz",
@@ -216,7 +213,7 @@ def makeSplicedCatalog(infile, outfile):
     '''
 
     statement = '''
-    python %(cgat_scripts)s/cgat_fasta2cDNA.py
+    cgat cgat_fasta2cDNA.py
     --log=%(outfile)s.log
     %(infile)s
     > %(outfile)s
@@ -284,7 +281,7 @@ def makeSailfishIndex(infile, outfile):
     outdir = "/".join(outfile.split("/")[:-1])
     job_threads = 8
     statement = '''
-    python %(cgat_scripts)s/fastq2tpm.py
+    cgat fastq2tpm.py
     --method=make_index
     --program=sailfish
     --index-fasta=%(infile)s
@@ -325,7 +322,7 @@ if PARAMS['paired']:
         job_memory = "1.5G"
 
         statement = '''
-        python %(cgat_scripts)s/fastq2tpm.py
+        cgat fastq2tpm.py
         --log=%(out_dir)s.log
         --program=sailfish
         --method=quant
@@ -364,7 +361,7 @@ else:
         count_file = "/".join([out_dir, "quant.sf"])
 
         statement = '''
-        python %(cgat_scripts)s/fastq2tpm.py
+        cgat fastq2tpm.py
         --log=%(outfile)s.log
         --program=sailfish
         --method=quant
@@ -651,7 +648,7 @@ def getContextStats(outfile):
     '''
 
     statement = '''
-    python %(cgat_scripts)s/extract_stats.py
+    cgat extract_stats.py
     --task=extract_table
     --log=%(outfile)s.log
     --database=%(mapping_db)s
@@ -670,7 +667,7 @@ def getAlignmentStats(outfile):
     '''
 
     statement = '''
-    python %(cgat_scripts)s/extract_stats.py
+    cgat extract_stats.py
     --task=extract_table
     --log=%(outfile)s.log
     --database=%(mapping_db)s
@@ -689,7 +686,7 @@ def getPicardAlignStats(outfile):
     '''
 
     statement = '''
-    python %(cgat_scripts)s/extract_stats.py
+    cgat extract_stats.py
     --log=%(outfile)s.log
     --task=extract_table
     --database=%(mapping_db)s
@@ -709,7 +706,7 @@ if PARAMS['paired']:
         '''
 
         statement = '''
-        python %(cgat_scripts)s/extract_stats.py
+        cgat extract_stats.py
         --log=%(outfile)s.log
         --task=extract_table
         --database=%(mapping_db)s
@@ -732,7 +729,7 @@ def getDuplicationStats(outfile):
     '''
 
     statement = '''
-    python %(cgat_scripts)s/extract_stats.py
+    cgat extract_stats.py
     --log=%(outfile)s.log
     --task=extract_table
     --database=%(mapping_db)s
@@ -755,7 +752,7 @@ def getCoverageStats(outfile):
     '''
 
     statement = '''
-    python %(cgat_scripts)s/extract_stats.py
+    cgat extract_stats.py
     --task=extract_table
     --log=%(outfile)s.log
     --database=%(mapping_db)s
@@ -814,7 +811,7 @@ def cleanQcTable(infile, outfile):
     '''
 
     statement = '''
-    python %(cgat_scripts)s/extract_stats.py
+    cgat extract_stats.py
     --task=clean_table
     --log=%(outfile)s.log
     %(infile)s

--- a/CGATPipelines/pipeline_scrnaseqqc.py
+++ b/CGATPipelines/pipeline_scrnaseqqc.py
@@ -166,7 +166,7 @@ else:
     else:
         DATADIR = PARAMS['data']
 
-CODE_LOCATION =  example=os.path.dirname(E.__file__)
+CODE_LOCATION = os.path.dirname(E.__file__)
 PARAMS['cgat_scripts'] = re.sub(r'CGAT.*', 'scripts', CODE_LOCATION)
 
 # --------------------------------------


### PR DESCRIPTION
Pinging @MikeDMorgan @Acribbs 

When running tests for `scrnaseqqc` pipeline with Jenkins, I found a problem regarding the location of some scripts used by this pipeline. Namely:
* cgat_fasta2cDNA.py
* extract_stats.py
* fastq2tpm.py

In this PR I propose a solution but can I ask why these scripts are not in the standard location? They look as standard CGAT scripts anyway and thus a better solution to the problem I mention here would be to use `scriptsdir` in `PARAMS`.

Please let me know your thoughts.