### PR TITLE
Hp pipeline mapping

### DIFF
--- a/CGATPipelines/PipelineGeneset.py
+++ b/CGATPipelines/PipelineGeneset.py
@@ -850,7 +850,7 @@ def loadProteinStats(infile, outfile):
     | cgat fasta2fasta
     --method=filter
     --filter-method=min-length=1
-    | awk 'match($0, /(>ENS[A-Z]+[0-9]+)(\.[0-9])*(.*)/, a) {print a[1], a[3]}
+    | awk 'match($0, /(>[a-zA-Z]+[0-9]+)(\.[0-9])*(.*)/, a) {print a[1], a[3]}
     !/^>/ {print}'
     | cgat fasta2table
     --log=%(outfile)s

--- a/CGATPipelines/PipelineMappingQC.py
+++ b/CGATPipelines/PipelineMappingQC.py
@@ -777,12 +777,16 @@ def loadIdxstats(infiles, outfile):
         df = df.append(reformatted_df, ignore_index=True)
         df.set_index('region', inplace=True)
         df1 = df[['mapped']].T
+        #set track as index
+        df1.set_index('track', inplace=True)
         dfs.append(df1)
 
     # merge dataframes into single table
     master_df = pd.concat(dfs)
     master_df.drop('*', axis=1, inplace=True)
-    master_df.to_csv(outf, sep='\t', index=False)
+    #transform dataframe to avoid reaching column limit
+    master_df=master_df.T
+    master_df.to_csv(outf, sep='\t', index=True)
     outf.close()
 
     P.load(outf.name,

--- a/CGATPipelines/PipelineMappingQC.py
+++ b/CGATPipelines/PipelineMappingQC.py
@@ -777,15 +777,15 @@ def loadIdxstats(infiles, outfile):
         df = df.append(reformatted_df, ignore_index=True)
         df.set_index('region', inplace=True)
         df1 = df[['mapped']].T
-        #set track as index
+        # set track as index
         df1.set_index('track', inplace=True)
         dfs.append(df1)
 
     # merge dataframes into single table
     master_df = pd.concat(dfs)
     master_df.drop('*', axis=1, inplace=True)
-    #transform dataframe to avoid reaching column limit
-    master_df=master_df.T
+    # transform dataframe to avoid reaching column limit
+    master_df = master_df.T
     master_df.to_csv(outf, sep='\t', index=True)
     outf.close()
 

--- a/CGATPipelines/pipeline_annotations.py
+++ b/CGATPipelines/pipeline_annotations.py
@@ -964,7 +964,7 @@ def buildCpGBed(infile, outfile):
     '''
 
     job_memory = "10G"
-    
+
     statement = '''
     cgat fasta2bed
         --method=cpg


### PR DESCRIPTION
transforms idxstats table to avoid sqlite3 column list limit in PipelineMappingQC.py and removes awk statements that hardcode search for ENS ids from PipelineGeneset.py