### PR TITLE
Ac input validation

### DIFF
--- a/CGATPipelines/Pipeline/Control.py
+++ b/CGATPipelines/Pipeline/Control.py
@@ -81,7 +81,7 @@ from CGATPipelines.Pipeline.Utils import isTest, getCaller, getCallerLocals
 from CGATPipelines.Pipeline.Execution import execute, startSession,\
     closeSession
 from CGATPipelines.Pipeline.Local import getProjectName, getPipelineName
-
+from CGATPipelines.Pipeline.Parameters import inputValidation
 # Set from Pipeline.py
 PARAMS = {}
 
@@ -856,7 +856,7 @@ def main(args=sys.argv):
     # and files exist, provide warnings and then ask the user to
     # specify whether they are comfortable to continue
     if options.input_validation:
-       P.inputValidation(PARAMS)
+       inputValidation(PARAMS)
 
     if options.pipeline_action == "check":
         counter, requirements = Requirements.checkRequirementsFromAllModules()

--- a/CGATPipelines/Pipeline/Control.py
+++ b/CGATPipelines/Pipeline/Control.py
@@ -778,6 +778,11 @@ def main(args=sys.argv):
                       help="RabbitMQ host to send log messages to "
                       "[default=%default].")
 
+    parser.add_option("--input-validation", dest="input_validation",
+                      action="store_true",
+                      help="perform input validation before starting "
+                      "[default=%default].")
+
     parser.set_defaults(
         pipeline_action=None,
         pipeline_format="svg",
@@ -793,7 +798,8 @@ def main(args=sys.argv):
         is_test=False,
         ruffus_checksums_level=0,
         rabbitmq_host="saruman",
-        rabbitmq_exchange="ruffus_pipelines")
+        rabbitmq_exchange="ruffus_pipelines",
+        input_validation=False)
 
     (options, args) = E.Start(parser,
                               add_cluster_options=True)
@@ -806,6 +812,7 @@ def main(args=sys.argv):
     # configuration files.
 
     PARAMS["dryrun"] = options.dry_run
+    PARAMS["input_validation"] = options.input_validation
 
     # use cli_cluster_* keys in PARAMS to ensure highest priority
     # of cluster_* options passed with the command-line
@@ -844,6 +851,12 @@ def main(args=sys.argv):
         options.pipeline_action = args[0]
         if len(args) > 1:
             options.pipeline_targets.extend(args[1:])
+
+    # add input validation to check that all of the directories
+    # and files exist, provide warnings and then ask the user to
+    # specify whether they are comfortable to continue
+    if options.input_validation:
+       P.inputValidation(PARAMS)
 
     if options.pipeline_action == "check":
         counter, requirements = Requirements.checkRequirementsFromAllModules()

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -439,7 +439,7 @@ def getParameters(filenames=["pipeline.ini", ],
     # and files exist, provide warnings and then ask the user to
     # specify whether they are comfortable to continue
 
-    if not only_import:
+    if only_import is not False:
         inputValidation(dict(PARAMS))
 
     return PARAMS

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -439,7 +439,7 @@ def getParameters(filenames=["pipeline.ini", ],
     # and files exist, provide warnings and then ask the user to
     # specify whether they are comfortable to continue
 
-    if only_import is not False:
+    if isTest() is False:
         inputValidation(dict(PARAMS))
 
     return PARAMS

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -239,7 +239,8 @@ def input_validation(PARAMS):
             if os.path.exists(value):
                 pass
             else:
-                E.warn("WARNING path does not exist %s" % (value))
+                E.warn('''%s: the %s path does not exist
+                ''' % (key, value))
                 
         # validate whether files exists that dont start with /
         pat = re.compile('\.gtf|\.gz')
@@ -247,18 +248,30 @@ def input_validation(PARAMS):
             if os.path.exists(value):
                 pass
             else:
-                E.warn("WARNING file does not exist %s" % (value))
+                E.warn('''%s: the %s file does exist
+                '''% (key, value))
     while True:
         start_pipeline = raw_input('''
-    ###################################################
-    Please check the WARNING messages and if you are 
-    happy then enter Y to continue or n to abort running
-    the pipeline.
-    ####################################################''')
-        if start_pipeline == "Y" or start_pipeline == "y":
+        ###########################################################
+
+        Please check the WARNING messages and if you are
+        happy then enter Y to continue or n to abort running
+        the pipeline.
+
+        ###########################################################
+        ''')
+        if start_pipeline.lower() == "y":
             break
-        if start_pipeline == "N" or start_pipeline == "n":
-            raise ValueError("You have stopped the pipeline")
+        if start_pipeline.lower() == "n":
+            raise ValueError('''
+            #######################################################
+
+            You have stopped the pipeline, please make sure you
+            check that file paths and names are correctly specified
+            in the pipeline.ini
+
+            #######################################################
+            ''')
 
 
 def getParameters(filenames=["pipeline.ini", ],

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -230,7 +230,7 @@ def configToDictionary(config):
     return p
 
 
-def input_validation(PARAMS):
+def inputValidation(PARAMS):
     for key, value in PARAMS.iteritems():
         value = str(value)
         
@@ -439,7 +439,8 @@ def getParameters(filenames=["pipeline.ini", ],
     # and files exist, provide warnings and then ask the user to
     # specify whether they are comfortable to continue
 
-    input_validation(dict(PARAMS))
+    if not only_import:
+        inputValidation(dict(PARAMS))
 
     return PARAMS
 

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -459,13 +459,6 @@ def getParameters(filenames=["pipeline.ini", ],
     # make sure that the dictionary reference has not changed
     assert id(PARAMS) == old_id
 
-    # add input validation to check that all of the directories
-    # and files exist, provide warnings and then ask the user to
-    # specify whether they are comfortable to continue
-
-    if isTest() is False:
-        inputValidation(dict(PARAMS))
-
     return PARAMS
 
 

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -230,6 +230,36 @@ def configToDictionary(config):
     return p
 
 
+def input_validation(PARAMS):
+    for key, value in PARAMS.iteritems():
+        value = str(value)
+        
+        # validate input files listed in PARAMS
+        if value.startswith("/"):
+            if os.path.exists(value):
+                pass
+            else:
+                E.warn("WARNING path does not exist %s" % (value))
+                
+        # validate whether files exists that dont start with /
+        pat = re.compile('\.gtf|\.gz')
+        if pat.search(value): 
+            if os.path.exists(value):
+                pass
+            else:
+                E.warn("WARNING file does not exist %s" % (value))
+    while True:
+        start_pipeline = raw_input('''
+    ###################################################
+    Please check the WARNING messages and if you are 
+    happy then enter Y to continue or n to abort running
+    the pipeline.
+    ####################################################''')
+        if start_pipeline == "Y" or start_pipeline == "y":
+            break
+        if start_pipeline == "N" or start_pipeline == "n":
+            raise ValueError("You have stopped the pipeline")
+
 
 def getParameters(filenames=["pipeline.ini", ],
                   defaults=None,
@@ -391,6 +421,13 @@ def getParameters(filenames=["pipeline.ini", ],
 
     # make sure that the dictionary reference has not changed
     assert id(PARAMS) == old_id
+
+    # add input validation to check that all of the directories
+    # and files exist, provide warnings and then ask the user to
+    # specify whether they are comfortable to continue
+
+    input_validation(dict(PARAMS))
+
     return PARAMS
 
 

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -231,9 +231,25 @@ def configToDictionary(config):
 
 
 def inputValidation(PARAMS):
+
+    missing_statement = "A missing value in the pipeline.ini was detected"
+    question_statement = "A ? was detected: please add a value in the ini file"
+    num_missing_value = 0
+    num_question_value = 0
+
     for key, value in PARAMS.iteritems():
+
         value = str(value)
-        
+
+        # check for missing values
+        if value == "":
+            num_missing_value += 1
+
+        # check for a question mark in the dictironary (indicates
+        # that there is a missing input parameter)
+        if "?" in value:
+            num_question_value += 1
+
         # validate input files listed in PARAMS
         if value.startswith("/"):
             if os.path.exists(value):
@@ -241,15 +257,23 @@ def inputValidation(PARAMS):
             else:
                 E.warn('''%s: the %s path does not exist
                 ''' % (key, value))
-                
-        # validate whether files exists that dont start with /
+
+        # validate whether files exists that dont start with "/"
+        # exist
         pat = re.compile('\.gtf|\.gz')
-        if pat.search(value): 
+        if pat.search(value):
             if os.path.exists(value):
                 pass
             else:
                 E.warn('''%s: the %s file does exist
-                '''% (key, value))
+                ''' % (key, value))
+
+    if num_missing_value > 0:
+        E.warn(missing_statement)
+
+    if num_question_value > 0:
+        E.warn(question_statement)
+
     while True:
         start_pipeline = raw_input('''
         ###########################################################


### PR DESCRIPTION
There is a new option to perform input validation on the pipeline.ini. When running a pipeline if you add the command line option `--input-validation` a series of warnings will be produced if options are missing or a file path or directory is missing or not accessible. Before running the pipeline you will have to then decide whether you are happy before typing Y to continue or n to stop. @CGATOxford/contributors I have tested it on the pipelines I am currently working on but maybe worth testing on other pipelines too.