### PR TITLE
pipeline_annotations bugfix

### DIFF
--- a/CGATPipelines/pipeline_annotations.py
+++ b/CGATPipelines/pipeline_annotations.py
@@ -663,6 +663,7 @@ def buildContigSizes(infile, outfile):
     df_contig.sort_values('contigs', inplace=True)
     df_contig.to_csv(outfile, sep="\t", header=False, index=False)
 
+
 @follows(mkdir('assembly.dir'))
 @files(os.path.join(PARAMS["genome_dir"], PARAMS["genome"] + ".fasta"),
        PARAMS['interface_contigs_bed'])
@@ -693,7 +694,6 @@ def buildContigBed(infile, outfile):
 
     outs.close()
 
-    
 
 @follows(mkdir('assembly.dir'))
 @files(os.path.join(PARAMS["genome_dir"], PARAMS["genome"] + ".fasta"),

--- a/CGATPipelines/pipeline_annotations.py
+++ b/CGATPipelines/pipeline_annotations.py
@@ -567,6 +567,7 @@ import re
 import os
 import glob
 import collections
+import pandas as pd
 from ruffus import follows, transform, merge, mkdir, files, jobs_limit,\
     suffix, regex, add_inputs
 
@@ -654,13 +655,13 @@ def buildContigSizes(infile, outfile):
 
     prefix = P.snip(infile, ".fasta")
     fasta = IndexedFasta.IndexedFasta(prefix)
-    outs = IOTools.openFile(outfile, "w")
+    contigs = []
 
     for contig, size in fasta.getContigSizes(with_synonyms=False).items():
-        outs.write("%s\t%i\n" % (contig, size))
-
-    outs.close()
-
+        contigs.append([contig, size])
+    df_contig = pd.DataFrame(contigs, columns=['contigs', 'size'])
+    df_contig.sort_values('contigs', inplace=True)
+    df_contig.to_csv(outfile, sep="\t", header=False, index=False)
 
 @follows(mkdir('assembly.dir'))
 @files(os.path.join(PARAMS["genome_dir"], PARAMS["genome"] + ".fasta"),
@@ -692,6 +693,7 @@ def buildContigBed(infile, outfile):
 
     outs.close()
 
+    
 
 @follows(mkdir('assembly.dir'))
 @files(os.path.join(PARAMS["genome_dir"], PARAMS["genome"] + ".fasta"),
@@ -1702,6 +1704,7 @@ def buildIntergenicRegions(infiles, outfile):
     infile, contigs = infiles
 
     statement = '''zcat %(infile)s
+    | sort -k1,1 -k2,2n
     | complementBed -i stdin -g %(contigs)s
     | gzip
     > %(outfile)s'''


### PR DESCRIPTION
Fixes Contig sorting for bed files and contig.tsv: complementBed tool requires both to be sorted.
Not previously detected as contigs were always removed, not detected in testing because only uses one contig)