### PR TITLE
add script to check for 3rd party dependencies

### DIFF
--- a/CGATPipelines/Pipeline/Control.py
+++ b/CGATPipelines/Pipeline/Control.py
@@ -852,9 +852,7 @@ def main(args=sys.argv):
         if len(args) > 1:
             options.pipeline_targets.extend(args[1:])
 
-    # add input validation to check that all of the directories
-    # and files exist, provide warnings and then ask the user to
-    # specify whether they are comfortable to continue
+    # see inputValidation function in Parameters.py
     if options.input_validation:
        inputValidation(PARAMS, sys.argv[0])
 

--- a/CGATPipelines/Pipeline/Control.py
+++ b/CGATPipelines/Pipeline/Control.py
@@ -856,7 +856,7 @@ def main(args=sys.argv):
     # and files exist, provide warnings and then ask the user to
     # specify whether they are comfortable to continue
     if options.input_validation:
-       inputValidation(PARAMS)
+       inputValidation(PARAMS, sys.argv[0])
 
     if options.pipeline_action == "check":
         counter, requirements = Requirements.checkRequirementsFromAllModules()

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -235,6 +235,8 @@ def inputValidation(PARAMS, pipeline_script=""):
 
     So far we just check that:
 
+        * all required 3rd party tools are on the PATH
+
         * input parameters are not empty
 
         * input parameters do not contain the "?" character (used as a

--- a/CGATPipelines/Pipeline/Parameters.py
+++ b/CGATPipelines/Pipeline/Parameters.py
@@ -230,7 +230,7 @@ def configToDictionary(config):
     return p
 
 
-def inputValidation(PARAMS):
+def inputValidation(PARAMS, pipeline_script=""):
     '''Inspects the PARAMS dictionary looking for problematic input values.
 
     So far we just check that:
@@ -244,10 +244,37 @@ def inputValidation(PARAMS):
           is readable
     '''
 
+    E.info('''=== Input Validation starts ===''')
+    E.info(''' Checking 3rd party dependencies ''')
+
+    ### check 3rd party dependencies ###
+    if len(pipeline_script) > 0:
+        # this import requires the PYTHONPATH in the following order
+        # PYTHONPATH=<src>/CGATPipelines:<src>/cgat
+        import scripts.cgat_check_deps as cd
+        deps, check_path_failures = cd.checkDepedencies(pipeline_script)
+        # print info about dependencies
+        if len(deps) == 0:
+            print('\nNo dependencies found.\n')
+        else:
+        # print dictionary ordered by value
+            for k in sorted(deps, key=deps.get, reverse=True):
+                print('\nProgram: {0!s} used {1} time(s)'.format(k, deps[k]))
+
+            n_failures = len(check_path_failures)
+            if n_failures == 0:
+                print('\nCongratulations! All required programs are available on your PATH\n')
+            else:
+                print('\nThe following programs are not on your PATH')
+                for p in check_path_failures:
+                    print('\n{0!s}'.format(p))
+                print
+
+    ### check PARAMS ###
     num_missing = 0
     num_questions = 0
 
-    E.info('''=== Input Validation starts ===''')
+    E.info(''' Checking pipeline configuration ''')
 
     for key, value in sorted(PARAMS.iteritems()):
 
@@ -256,13 +283,13 @@ def inputValidation(PARAMS):
 
         # check for missing values
         if value == "":
-            E.warn('"{}" is empty, is that expected?'.format(key))
+            print('\n"{}" is empty, is that expected?'.format(key))
             num_missing += 1
 
         # check for a question mark in the dictironary (indicates
         # that there is a missing input parameter)
         if "?" in value:
-            E.warn('"{}" is not defined (?), is that expected?'.format(key))
+            print('\n"{}" is not defined (?), is that expected?'.format(key))
             num_questions += 1
 
         # validate input files listed in PARAMS
@@ -274,7 +301,7 @@ def inputValidation(PARAMS):
             if os.access(value, os.R_OK):
                 pass
             else:
-                E.warn('"{}": "{}" is not readable'.format(key, value))
+                print('\n"{}": "{}" is not readable'.format(key, value))
 
     if num_missing == 0 and num_questions == 0:
         while True:

--- a/scripts/cgat_check_deps.py
+++ b/scripts/cgat_check_deps.py
@@ -1,0 +1,152 @@
+'''
+cgat_check_deps.py - check whether the software dependencies are on your PATH
+=============================================================================
+
+Purpose
+-------
+
+.. This script takes the name of a CGAT pipeline and checks whether all
+programs used in the pipeline (via "statement" and "P.run()") can be
+located on the PATH.
+
+Usage
+-----
+
+.. cgat cgat_check_deps --pipeline </path/to/pipeline_name.py>
+
+Example::
+
+   cgat cgat_check_deps --pipeline CGATPipelines/pipeline_annotations.py
+
+Type::
+
+   cgat cgat_check_deps --help
+
+for command line help.
+
+Command line options
+--------------------
+
+'''
+
+import os
+import sys
+import re
+import subprocess
+import CGAT.Experiment as E
+import CGAT.IOTools as IOTools
+
+# load options from the config file
+import CGATPipelines.Pipeline as P
+P.getParameters(
+    ["%s/pipeline.ini" % os.path.splitext(__file__)[0],
+     "../pipeline.ini",
+     "pipeline.ini"])
+
+PARAMS = P.PARAMS
+
+
+def main(argv=None):
+    """script main.
+    parses command line options in sys.argv, unless *argv* is given.
+    """
+
+    if argv is None:
+        argv = sys.argv
+
+    # setup command line parser
+    parser = E.OptionParser(version="%prog version: $Id$",
+                            usage=globals()["__doc__"])
+
+    parser.add_option("-p", "--pipeline", dest="pipeline", type="string",
+                      help="Path to pipeline script")
+
+    parser.add_option("-s", "--print-summary", dest="summary", action="store_true", default=False,
+                      help="Print how many times a program is used [default=%default]")
+
+    # add common options (-h/--help, ...) and parse command line
+    (options, args) = E.Start(parser, argv=argv)
+
+    # check existence of pipeline script
+    if not os.access(options.pipeline, os.R_OK):
+        raise IOError("Pipeline %s was not found\n" % options.pipeline)
+
+    # parse pipeline script
+    statement = '''awk '/statement =/,/P.run()/ {print}' %s
+                   | grep -v '#'
+                   | tr '\n' ' '
+                   | tr '"' ' '
+                   | sed 's/statement =//g'
+                   | sed 's/P.run()//g'
+                   '''
+    # the code below has been adapted from the Execution module of Pipeline.py
+    # cleaning up of statement
+    # remove new lines and superfluous spaces and tabs
+    statement = " ".join(re.sub("\t+", " ", statement).split("\n")).strip()
+    if statement.endswith(";"):
+        statement = statement[:-1]
+
+    process = subprocess.Popen(statement % options.pipeline,
+                               shell=True,
+                               stdin=subprocess.PIPE,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+
+    # get process output
+    stdout, stderr = process.communicate()
+
+    # check process status
+    if process.returncode != 0:
+        raise OSError(
+            "Child was terminated by signal %i: \n"
+            "The stderr was: \n%s\n%s\n" %
+             (-process.returncode, stderr, statement))
+
+    print stdout
+
+    # dictionary where:
+    # key = program name
+    # value = number of times it has been called
+    deps = {}
+
+    for slice in stdout.split("'''"):
+        # clean up white duplicated spaces
+        clean_slice = ' '.join(slice.split())
+        if len(clean_slice) > 0:
+            for command in clean_slice.split("|"):
+                # take program name
+                groups  = re.match("^\s*(\w+)", command)
+                if groups is not None:
+                    # program name is first match
+                    prog_name = groups.group(0)
+                    # clean up duplicated white spaces
+                    prog_name = ' '.join(prog_name.split())
+                    if prog_name not in deps:
+                        deps[prog_name] = 1
+                    else:
+                        deps[prog_name]+= 1
+
+    check_path_failures = []
+
+    # print dictionary ordered by value
+    for k in sorted(deps, key=deps.get, reverse=True):
+        if options.summary:
+            print 'Program: {0!s} used {1} time(s) \n'.format(k,deps[k])
+        if len(IOTools.which(k)) == 0:
+            check_path_failures.append(k)
+            print 'Program: {0!s} is NOT on your PATH!\n'.format(k)
+
+    n_failures = len(check_path_failures)
+    if n_failures == 0:
+        print 'Congratulations! All required programs are available on your PATH\n'
+    else:
+        print 'The following programs are not on your PATH\n'
+        for p in check_path_failure:
+            print '{0!s}\n'.format(p)
+
+    # write footer and output benchmark information.
+    E.Stop()
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+

--- a/scripts/cgat_check_deps.py
+++ b/scripts/cgat_check_deps.py
@@ -74,13 +74,12 @@ def checkDepedencies(pipeline):
            hasattr(node.targets[0], 'id') and \
            node.targets[0].id == "statement" and \
            hasattr(node.value, 's'):
-#        if hasattr(node, 'targets') and hasattr(node.targets[0], 'id') and node.targets[0].id == "statement":
-             statement = node.value.s
-             # clean up statement, code copied from Execution module of Pipeline.py
-             statement = " ".join(re.sub("\t+", " ", statement).split("\n")).strip()
-             if statement.endswith(";"):
-                 statement = statement[:-1]
-             statements.append(statement)
+            statement = node.value.s
+            # clean up statement, code copied from Execution module of Pipeline.py
+            statement = " ".join(re.sub("\t+", " ", statement).split("\n")).strip()
+            if statement.endswith(";"):
+                statement = statement[:-1]
+            statements.append(statement)
 
     # dictionary where:
     # key = program name
@@ -94,13 +93,13 @@ def checkDepedencies(pipeline):
                   'attach',
                   'insert',
                   'module',
+                  'checkpoint',
                   'for']
 
     for statement in statements:
         for command in statement.split("|"):
-            print "COMMAND: ", command
-            # take program name
-            groups = re.match("^\s*(\w+)", command)
+            # take program name, thanks http://pythex.org/
+            groups = re.match("^\s*([\w|\-|\.]+)", command)
             if groups is not None:
                 # program name is first match
                 prog_name = groups.group(0)

--- a/scripts/cgat_check_deps.py
+++ b/scripts/cgat_check_deps.py
@@ -5,18 +5,28 @@ cgat_check_deps.py - check whether the software dependencies are on your PATH
 Purpose
 -------
 
-.. This script takes the name of a CGAT pipeline and checks whether all
-programs used in the pipeline (via "statement" and "P.run()") can be
-located on the PATH.
+.. The goal of this script is to provide a list of third-party command-line
+programs used in a Python script given as input, and check whether
+they are on your PATH. This is useful to identify dependencies across all
+CGAT pipelines and module files.
+
+This script takes the path to a Python script, which is expected to call
+command-line programs like we do in CGAT pipelines, i.e.:
+
+   statement = """cmd-1 | cmd-2 | cmd-3""""
+   P.run()
+
+Programs called other way (e.g. using subprocess) will not be picked up
+by this script.
 
 Usage
 -----
 
-.. cgat cgat_check_deps --pipeline </path/to/pipeline_name.py> [--print-summary]
+.. python cgat_check_deps --pipeline </path/to/pipeline_name.py> [--print-summary]
 
 Example::
 
-   cgat cgat_check_deps --pipeline CGATPipelines/pipeline_annotations.py
+   python cgat_check_deps --pipeline CGATPipelines/pipeline_annotations.py
 
 Type::
 
@@ -32,18 +42,10 @@ Command line options
 import os
 import sys
 import re
+import ast
 import subprocess
 import CGAT.Experiment as E
 import CGAT.IOTools as IOTools
-
-# load options from the config file
-import CGATPipelines.Pipeline as P
-P.getParameters(
-    ["%s/pipeline.ini" % os.path.splitext(__file__)[0],
-     "../pipeline.ini",
-     "pipeline.ini"])
-
-PARAMS = P.PARAMS
 
 
 def checkDepedencies(pipeline):
@@ -56,60 +58,56 @@ def checkDepedencies(pipeline):
         raise IOError("The given input is a folder, and must be a script\n")
 
     # parse pipeline script
-    statement = '''awk '/statement =/,/P.run()/ {print}' %s
-                   | grep -v '#'
-                   | tr '\n' ' '
-                   | tr '"' ' '
-                   | sed 's/statement =//g'
-                   | sed 's/P.run()//g'
-                   '''
-    # the code below has been adapted from the Execution module of Pipeline.py
-    # cleaning up of statement
-    # remove new lines and superfluous spaces and tabs
-    statement = " ".join(re.sub("\t+", " ", statement).split("\n")).strip()
-    if statement.endswith(";"):
-        statement = statement[:-1]
+    with open(pipeline) as f:
+        tree = ast.parse(f.read())
 
-    process = subprocess.Popen(statement % pipeline,
-                               shell=True,
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
+    # list to store all statements = ''' <commands> '''
+    statements = []
 
-    # get process output
-    stdout, stderr = process.communicate()
+    # inspired by
+    # https://docs.python.org/3/library/ast.html#module-ast
+    # http://bit.ly/2rDf5xu
+    # http://bit.ly/2r0Uv9t
+    for node in ast.walk(tree):
+        if type(node) is ast.Assign and \
+           hasattr(node, 'targets') and \
+           hasattr(node.targets[0], 'id') and \
+           node.targets[0].id == "statement" and \
+           hasattr(node.value, 's'):
+#        if hasattr(node, 'targets') and hasattr(node.targets[0], 'id') and node.targets[0].id == "statement":
+             statement = node.value.s
+             # clean up statement, code copied from Execution module of Pipeline.py
+             statement = " ".join(re.sub("\t+", " ", statement).split("\n")).strip()
+             if statement.endswith(";"):
+                 statement = statement[:-1]
+             statements.append(statement)
 
-    # check process status
-    if process.returncode != 0:
-        raise OSError(
-            "Child was terminated by signal %i: \n"
-            "The stderr was: \n%s\n%s\n" %
-            (-process.returncode, stderr, statement))
-
-    # check awk command output
-    if len(stdout) == 0:
-        raise Exception("The given input does not contain P.run() statements.")
-
-    # check awk command output
-    #print stdout
- 
     # dictionary where:
     # key = program name
     # value = number of times it has been called
     deps = {}
 
-    for slice in stdout.split("'''"):
-        # clean up white duplicated spaces
-        clean_slice = ' '.join(slice.split())
-        if len(clean_slice) > 0:
-            for command in clean_slice.split("|"):
-                # take program name
-                groups = re.match("^\s*(\w+)", command)
-                if groups is not None:
-                    # program name is first match
-                    prog_name = groups.group(0)
-                    # clean up duplicated white spaces
-                    prog_name = ' '.join(prog_name.split())
+    # set of names that are not proper deps
+    exceptions = ['create',
+                  'drop',
+                  'select',
+                  'attach',
+                  'insert',
+                  'module',
+                  'for']
+
+    for statement in statements:
+        for command in statement.split("|"):
+            print "COMMAND: ", command
+            # take program name
+            groups = re.match("^\s*(\w+)", command)
+            if groups is not None:
+                # program name is first match
+                prog_name = groups.group(0)
+                # clean up duplicated white spaces
+                prog_name = ' '.join(prog_name.split())
+                # filter exceptions
+                if prog_name.lower() not in exceptions:
                     if prog_name not in deps:
                         deps[prog_name] = 1
                     else:
@@ -147,22 +145,26 @@ def main(argv=None):
     # add common options (-h/--help, ...) and parse command line
     (options, args) = E.Start(parser, argv=argv)
 
-    # check pipeline dependencies
+    # get dependencies dependencies
     deps, check_path_failures = checkDepedencies(options.pipeline)
 
-    # print dictionary ordered by value
-    if options.summary:
-        for k in sorted(deps, key=deps.get, reverse=True):
-            print('\nProgram: {0!s} used {1} time(s)'.format(k, deps[k]))
-
-    n_failures = len(check_path_failures)
-    if n_failures == 0:
-        print('\nCongratulations! All required programs are available on your PATH\n')
+    # print info about dependencies
+    if len(deps) == 0:
+        print('\nNo dependencies found.\n')
     else:
-        print('\nThe following programs are not on your PATH')
-        for p in check_path_failures:
-            print('\n{0!s}'.format(p))
-        print
+        # print dictionary ordered by value
+        if options.summary:
+            for k in sorted(deps, key=deps.get, reverse=True):
+                print('\nProgram: {0!s} used {1} time(s)'.format(k, deps[k]))
+
+        n_failures = len(check_path_failures)
+        if n_failures == 0:
+            print('\nCongratulations! All required programs are available on your PATH\n')
+        else:
+            print('\nThe following programs are not on your PATH')
+            for p in check_path_failures:
+                print('\n{0!s}'.format(p))
+            print
 
     # write footer and output benchmark information.
     E.Stop()

--- a/scripts/cgat_check_deps.py
+++ b/scripts/cgat_check_deps.py
@@ -12,7 +12,7 @@ located on the PATH.
 Usage
 -----
 
-.. cgat cgat_check_deps --pipeline </path/to/pipeline_name.py>
+.. cgat cgat_check_deps --pipeline </path/to/pipeline_name.py> [--print-summary]
 
 Example::
 
@@ -46,30 +46,11 @@ P.getParameters(
 PARAMS = P.PARAMS
 
 
-def main(argv=None):
-    """script main.
-    parses command line options in sys.argv, unless *argv* is given.
-    """
-
-    if argv is None:
-        argv = sys.argv
-
-    # setup command line parser
-    parser = E.OptionParser(version="%prog version: $Id$",
-                            usage=globals()["__doc__"])
-
-    parser.add_option("-p", "--pipeline", dest="pipeline", type="string",
-                      help="Path to pipeline script")
-
-    parser.add_option("-s", "--print-summary", dest="summary", action="store_true", default=False,
-                      help="Print how many times a program is used [default=%default]")
-
-    # add common options (-h/--help, ...) and parse command line
-    (options, args) = E.Start(parser, argv=argv)
+def checkDepedencies(pipeline):
 
     # check existence of pipeline script
-    if not os.access(options.pipeline, os.R_OK):
-        raise IOError("Pipeline %s was not found\n" % options.pipeline)
+    if not os.access(pipeline, os.R_OK):
+        raise IOError("Pipeline %s was not found\n" % pipeline)
 
     # parse pipeline script
     statement = '''awk '/statement =/,/P.run()/ {print}' %s
@@ -86,7 +67,7 @@ def main(argv=None):
     if statement.endswith(";"):
         statement = statement[:-1]
 
-    process = subprocess.Popen(statement % options.pipeline,
+    process = subprocess.Popen(statement % pipeline,
                                shell=True,
                                stdin=subprocess.PIPE,
                                stdout=subprocess.PIPE,
@@ -102,7 +83,8 @@ def main(argv=None):
             "The stderr was: \n%s\n%s\n" %
              (-process.returncode, stderr, statement))
 
-    print stdout
+    # check awk command output
+    #print stdout
 
     # dictionary where:
     # key = program name
@@ -126,23 +108,54 @@ def main(argv=None):
                     else:
                         deps[prog_name]+= 1
 
+    # list of unmet dependencies
     check_path_failures = []
 
     # print dictionary ordered by value
     for k in sorted(deps, key=deps.get, reverse=True):
-        if options.summary:
-            print 'Program: {0!s} used {1} time(s) \n'.format(k,deps[k])
-        if len(IOTools.which(k)) == 0:
+        if IOTools.which(k) is None:
             check_path_failures.append(k)
-            print 'Program: {0!s} is NOT on your PATH!\n'.format(k)
+
+    return deps, check_path_failures
+
+
+def main(argv=None):
+    """script main.
+    parses command line options in sys.argv, unless *argv* is given.
+    """
+
+    if argv is None:
+        argv = sys.argv
+
+    # setup command line parser
+    parser = E.OptionParser(version="%prog version: $Id$",
+                            usage=globals()["__doc__"])
+
+    parser.add_option("-p", "--pipeline", dest="pipeline", type="string",
+                      help="Path to pipeline script")
+
+    parser.add_option("-s", "--print-summary", dest="summary", action="store_true", default=False,
+                      help="Print how many times a program is used [default=%default]")
+
+    # add common options (-h/--help, ...) and parse command line
+    (options, args) = E.Start(parser, argv=argv)
+
+    # check pipeline dependencies
+    deps, check_path_failures = checkDepedencies(options.pipeline)
+
+    # print dictionary ordered by value
+    if options.summary:
+        for k in sorted(deps, key=deps.get, reverse=True):
+            print('\nProgram: {0!s} used {1} time(s)'.format(k,deps[k]))
 
     n_failures = len(check_path_failures)
     if n_failures == 0:
-        print 'Congratulations! All required programs are available on your PATH\n'
+        print('\nCongratulations! All required programs are available on your PATH\n')
     else:
-        print 'The following programs are not on your PATH\n'
-        for p in check_path_failure:
-            print '{0!s}\n'.format(p)
+        print('\nThe following programs are not on your PATH')
+        for p in check_path_failures:
+            print('\n{0!s}'.format(p))
+        print
 
     # write footer and output benchmark information.
     E.Stop()


### PR DESCRIPTION
Purpose
-------

The goal of this script is to provide a list of third-party command-line programs used in a Python script given as input, and check whether they are on your PATH. This is useful to identify dependencies across all CGAT pipelines and module files.

This script takes the path to a Python script, which is expected to call command-line programs like we do in CGAT pipelines, i.e.:

```
statement = """cmd-1 | cmd-2 | cmd-3""""
P.run()
```

Programs called other way (e.g. using subprocess) will not be picked up
by this script.

Usage
-----
```
python cgat_check_deps --pipeline </path/to/file.py> [--print-summary]
```

Example:

```
python cgat_check_deps --pipeline CGATPipelines/pipeline_annotations.py
python cgat_check_deps --pipeline CGATPipelines/PipelineMapping.py
```

Pipeline.py
----

Now when you run your pipeline with `--input-validation` it will also check whether 3rd party tools are available on your PATH
