### PR TITLE
Kb strandedness rnaseqqc

### DIFF
--- a/CGATPipelines/pipeline_rnaseqqc.py
+++ b/CGATPipelines/pipeline_rnaseqqc.py
@@ -1836,7 +1836,9 @@ def plotStrandednessSalmon(infile, outfile):
          loadAltContextStats,
          plotSailfishSaturation,
          plotTopGenesHeatmap,
-         plotExpression)
+         plotExpression,
+         plotStrandednessSalmon,
+         loadStrandednessSalmon)
 def full():
     pass
 

--- a/CGATPipelines/pipeline_rnaseqqc/pipeline.ini
+++ b/CGATPipelines/pipeline_rnaseqqc/pipeline.ini
@@ -104,6 +104,26 @@ library_type=FR
 index_dir=/ifs/mirror/genomes/hisat
 
 ################################################################
+#
+# salmon options
+#
+################################################################
+[salmon]
+
+# String providing additional options to append to the salmon quant
+# command
+# optional arguments include:
+# --extraSensitive
+options=
+
+# kmer size for salmon library
+kmer=31
+
+threads=1
+
+memory=2G
+
+################################################################
 # bias analysis options
 [bias]
 # bin=25 works fine for ~5000 genes. Maybe want more bins if more genes.


### PR DESCRIPTION
Added new functions to pipeline_rnaseqqc to run Salmon in order to check the strandedness of the library, which is required as an input for various mappers.  The output is summarised in a table and plotted.