### PR TITLE
Remove unused imports

### DIFF
--- a/CGATPipelines/Pipeline/Execution.py
+++ b/CGATPipelines/Pipeline/Execution.py
@@ -26,7 +26,7 @@ from CGAT.IOTools import snip as snip
 
 from CGATPipelines.Pipeline.Utils import getCallerLocals
 from CGATPipelines.Pipeline.Parameters import substituteParameters
-from CGATPipelines.Pipeline.Files import getTempFilename, getTempFile
+from CGATPipelines.Pipeline.Files import getTempFilename
 from CGATPipelines.Pipeline.Cluster import *
 
 # talking to a cluster

--- a/CGATPipelines/PipelineEnrichmentGSEA.py
+++ b/CGATPipelines/PipelineEnrichmentGSEA.py
@@ -141,24 +141,12 @@ Mootha, Lindgren, et al. (2003, Nat Genet 34, 267-273).
 =============================================
 '''
 import pandas as pd
-import CGAT.IOTools as IOTools
 import sqlite3
 import os
-import rpy2
-import copy
-import rpy2.robjects as robjects
-import rpy2.interactive as r
-import rpy2.interactive.packages
-import scipy.stats as stats
-from CGATPipelines.Pipeline import cluster_runnable
 import CGAT.Experiment as E
-import ast as ast
 import numpy as np
-import itertools as ITL
 import csv
 import os
-import string
-from toposort import toposort_flatten
 
 
 def getTables(dbname):

--- a/CGATPipelines/PipelineExomeAncestry.py
+++ b/CGATPipelines/PipelineExomeAncestry.py
@@ -7,7 +7,6 @@ from CGATPipelines.Pipeline import cluster_runnable
 import json
 import decimal
 from sklearn.cluster import KMeans
-import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
 import matplotlib.patches as mpatches

--- a/CGATPipelines/PipelineGSEnrichment.py
+++ b/CGATPipelines/PipelineGSEnrichment.py
@@ -2,11 +2,9 @@ import pandas as pd
 import CGAT.IOTools as IOTools
 import sqlite3
 import os
-import rpy2
 import copy
 import rpy2.robjects as robjects
 import rpy2.interactive as r
-import rpy2.interactive.packages
 import scipy.stats as stats
 from CGATPipelines.Pipeline import cluster_runnable
 import CGAT.Experiment as E

--- a/CGATPipelines/PipelineGSEnrichment.py
+++ b/CGATPipelines/PipelineGSEnrichment.py
@@ -5,6 +5,7 @@ import os
 import copy
 import rpy2.robjects as robjects
 import rpy2.interactive as r
+import rpy2.interactive.packages
 import scipy.stats as stats
 from CGATPipelines.Pipeline import cluster_runnable
 import CGAT.Experiment as E

--- a/CGATPipelines/PipelineGeneInfo.py
+++ b/CGATPipelines/PipelineGeneInfo.py
@@ -2,7 +2,6 @@ import CGATPipelines.Pipeline as P
 from Bio import Entrez
 import numpy as np
 import httplib2
-import json as json
 import sqlite3
 from intermine.webservice import Service as SS
 import string

--- a/CGATPipelines/PipelineGeneset.py
+++ b/CGATPipelines/PipelineGeneset.py
@@ -17,7 +17,6 @@ import os
 import collections
 import sqlite3
 import pandas as pd
-import pandas.io.sql as pdsql
 
 import CGAT.IOTools as IOTools
 import CGATPipelines.Pipeline as P

--- a/CGATPipelines/PipelineIntervals.py
+++ b/CGATPipelines/PipelineIntervals.py
@@ -42,7 +42,6 @@ Reference
 import shutil
 import random
 import re
-import glob
 import os
 import collections
 import sqlite3

--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -82,7 +82,6 @@ import os
 import glob
 import collections
 import re
-import gzip
 import itertools
 import CGATPipelines.Pipeline as P
 import logging as L

--- a/CGATPipelines/PipelinePeakcalling.py
+++ b/CGATPipelines/PipelinePeakcalling.py
@@ -11,11 +11,8 @@ import pysam
 import numpy as np
 import shutil
 from CGATPipelines.Pipeline import cluster_runnable
-import rpy2
 from rpy2.robjects import r as R
-import rpy2.robjects as ro
 from rpy2.robjects import pandas2ri
-from rpy2.robjects.packages import importr
 pandas2ri.activate()
 
 
@@ -1175,7 +1172,6 @@ class Peakcaller(object):
         infile: str
             path to bam file
         '''
-        pass
 
 
 class Macs2Peakcaller(Peakcaller):

--- a/CGATPipelines/PipelineRnaseq.py
+++ b/CGATPipelines/PipelineRnaseq.py
@@ -45,7 +45,6 @@ import numpy as np
 import os
 import pandas as pd
 import re
-import shutil
 
 
 from rpy2.robjects import r as R
@@ -233,11 +232,9 @@ class Quantifier(object):
 
     def run_transcript(self):
         ''' generate transcript-level quantification estimates'''
-        pass
 
     def run_gene(self):
         ''' generate gene-level quantification estimates'''
-        pass
 
     def run_all(self):
         ''' '''

--- a/CGATPipelines/PipelineRrbs.py
+++ b/CGATPipelines/PipelineRrbs.py
@@ -34,7 +34,6 @@ Code
 import os
 import re
 import sqlite3
-import collections
 import itertools
 import copy
 import CGATPipelines.Pipeline as P

--- a/CGATPipelines/PipelineSplicing.py
+++ b/CGATPipelines/PipelineSplicing.py
@@ -52,7 +52,6 @@ Requirements
 
 '''
 
-from ruffus import *
 import os
 import random
 import itertools

--- a/CGATPipelines/PipelineTransfacMatch.py
+++ b/CGATPipelines/PipelineTransfacMatch.py
@@ -10,7 +10,6 @@ PipelineTransfacMatch.py
 ################
 import re
 import os
-import CGAT.IOTools as IOTools
 import sqlite3
 import collections
 import CGATPipelines.Pipeline as P

--- a/CGATPipelines/pipeline_annotations.py
+++ b/CGATPipelines/pipeline_annotations.py
@@ -577,7 +577,6 @@ import CGAT.Experiment as E
 import CGATPipelines.Pipeline as P
 import CGAT.IndexedFasta as IndexedFasta
 import CGAT.IOTools as IOTools
-import CGAT.GTF as GTF
 import CGAT.Database as Database
 import CGAT.Biomart as Biomart
 import CGATPipelines.PipelineGeneset as PipelineGeneset
@@ -2861,7 +2860,6 @@ def loadIntervalSummary(infile, outfile):
          buildCpGBed)
 def assembly():
     """convenience target : assembly derived annotations"""
-    pass
 
 
 @follows(buildGeneSet,
@@ -2882,7 +2880,6 @@ def assembly():
          )
 def ensembl():
     """convenience target : ENSEMBL geneset derived annotations"""
-    pass
 
 
 @follows(buildPeptideFasta,
@@ -2890,7 +2887,6 @@ def ensembl():
          buildCDNAFasta)
 def fasta():
     """convenience target : sequence collections"""
-    pass
 
 
 @follows(buildTranscriptRegions,
@@ -2903,7 +2899,6 @@ def fasta():
          buildIntergenicRegions)
 def geneset():
     """convenience target : geneset derived annotations"""
-    pass
 
 
 @follows(importRepeatsFromUCSC,
@@ -2913,7 +2908,6 @@ def geneset():
          countTotalRepeatLength)
 def ucsc():
     """convenience target : UCSC derived annotations"""
-    pass
 
 
 # annotation targets are only intrinsic data sets
@@ -2925,7 +2919,6 @@ def ucsc():
          annotateGenome)
 def annotations():
     """convenience target : gene based annotations"""
-    pass
 
 
 # enrichment targets include extrinsic data sets such
@@ -2935,20 +2928,17 @@ def annotations():
          buildGenomicFunctionalAnnotation)
 def enrichment():
     """convenience target : annotations for enrichment analysis"""
-    pass
 
 
 @follows(loadGOAssignments,
          loadKEGGAssignments)
 def ontologies():
     """convenience target : ontology information"""
-    pass
 
 
 @follows(_gwas)
 def gwas():
     """convenience target : import GWAS data"""
-    pass
 
 
 @follows(loadGTFStats,
@@ -2956,7 +2946,6 @@ def gwas():
          loadIntervalSummary)
 def summary():
     '''convenience target : summary'''
-    pass
 
 
 # @follows(calculateMappability, countMappableBases,
@@ -2979,7 +2968,6 @@ def summary():
          gwas)
 def full():
     '''build all targets - note: run summary separately afterwards.'''
-    pass
 
 ###################################################################
 ###################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_annotations/trackers/AnnotationReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_annotations/trackers/AnnotationReport.py
@@ -1,6 +1,5 @@
 from CGATReport.Tracker import *
 from CGATReport.Utils import PARAMS as P
-from collections import OrderedDict as odict
 
 ###################################################################
 # parameterization

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from CGATReport import Cache
-from CGATReport import Utils
 from CGATReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/Mapping.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/Mapping.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 from cpgReport import *
 
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/cpgReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/cpgReport.py
@@ -1,13 +1,7 @@
-import os
-import sys
-import re
-import types
-import itertools
 import glob
 import PipelineTracks
 
 from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 from CGATReport.Utils import PARAMS as P
 
 EXPORTDIR = P['cpg_exportdir']

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs.py
@@ -1,14 +1,4 @@
 import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_annotations.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_annotations.py
@@ -1,16 +1,7 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
 import numpy
 import numpy.ma
-import Stats
-import Histogram
 import cpgReport
 
-from CGATReport.Tracker import *
 from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_cgi_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_cgi_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_interval_comparison.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_interval_comparison.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_interval_lists.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_interval_lists.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_parameter_correlation.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_parameter_correlation.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_shared_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_shared_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_tss_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_tss_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_unique_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/macs_unique_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/predicted_cgis.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/predicted_cgis.py
@@ -1,13 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/sicer.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/sicer.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/zinba.py
+++ b/CGATPipelines/pipeline_docs/pipeline_cpg/trackers/zinba.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_exome/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from CGATReport import Cache
-from CGATReport import Utils
 from CGATReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_exome/trackers/Coverage.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome/trackers/Coverage.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_exome/trackers/Filtered.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome/trackers/Filtered.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_exome/trackers/InsertSize.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome/trackers/InsertSize.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_exome/trackers/Mapping.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome/trackers/Mapping.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_exome/trackers/VarStats.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome/trackers/VarStats.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_exome_cancer/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome_cancer/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from SphinxReport import Cache
-from SphinxReport import Utils
 from SphinxReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/Coverage.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/Coverage.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/Filtered.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/Filtered.py
@@ -1,11 +1,6 @@
-import os
-import sys
 import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/InsertSize.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/InsertSize.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/Mapping.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/Mapping.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/VarStats.py
+++ b/CGATPipelines/pipeline_docs/pipeline_exome_cancer/trackers/VarStats.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from collections import OrderedDict as odict
 from exomeReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/Annotations.py
+++ b/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/Annotations.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from IntervalReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/Context.py
+++ b/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/Context.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
 from IntervalReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/GeneProfile.py
+++ b/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/GeneProfile.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from IntervalReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/IntervalReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/IntervalReport.py
@@ -3,7 +3,6 @@ from CGATReport.Tracker import *
 from CGATReport.Utils import PARAMS as P
 
 
-
 ###################################################################
 ###################################################################
 # parameterization

--- a/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/IntervalReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/IntervalReport.py
@@ -1,19 +1,8 @@
-import os
-import sys
-import re
-import types
-import itertools
-import glob
 
 from CGATReport.Tracker import *
 from CGATReport.Utils import PARAMS as P
-from collections import OrderedDict as odict
 
-import CGAT.IOTools as IOTools
-import CGAT.Stats as Stats
 
-from CGATReport.ResultBlock import ResultBlock, ResultBlocks
-from CGATReport import Utils
 
 ###################################################################
 ###################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/Nucleotide.py
+++ b/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/Nucleotide.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 from IntervalReport import *
 
 import Annotations

--- a/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/Peaks.py
+++ b/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/Peaks.py
@@ -1,9 +1,4 @@
 import os
-import sys
-import re
-import types
-import itertools
-import math
 
 from IntervalReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/TSS.py
+++ b/CGATPipelines/pipeline_docs/pipeline_intervals/trackers/TSS.py
@@ -1,8 +1,4 @@
 import os
-import sys
-import re
-import types
-import itertools
 import Annotations
 
 from CGATReport.Tracker import *

--- a/CGATPipelines/pipeline_docs/pipeline_mapping/trackers/Validation.py
+++ b/CGATPipelines/pipeline_docs/pipeline_mapping/trackers/Validation.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
 from MappingReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_mapping_benchmark/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_mapping_benchmark/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from CGATReport import Cache
-from CGATReport import Utils
 from CGATReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_mapping_benchmark/trackers/Mapping.py
+++ b/CGATPipelines/pipeline_docs/pipeline_mapping_benchmark/trackers/Mapping.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 from titrationReport import *
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/pipeline_metagenomeassembly.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/pipeline_metagenomeassembly.py
@@ -137,21 +137,18 @@ Code
 from ruffus import *
 
 import Experiment as E
-import logging as L
-import Database, CSV
 
-import sys, os, re, shutil, itertools, math, glob, time, gzip, collections, random
+import collections
+import glob
+import os
+import re
+import sys
 
-import numpy, sqlite3
-import GFF, GTF, IOTools, IndexedFasta
+import sqlite3
+import IOTools
 from rpy2.robjects import r as R
-import rpy2.robjects as ro
-import rpy2.robjects.vectors as rovectors
-from rpy2.rinterface import RRuntimeError
 import PipelineMapping
 import PipelineGenomeAssembly
-import FastaIterator
-import metaphlan_utils
 import PipelineMapping
 import PipelineMappingQC
 

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from CGATReport import Cache
-from CGATReport import Utils
 from CGATReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/Assembly.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/Assembly.py
@@ -1,6 +1,4 @@
 from CGATReport.Tracker import *
-import sqlite3
-import collections
 import numpy as np
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/AssemblyCoverage.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/AssemblyCoverage.py
@@ -1,6 +1,4 @@
 from CGATReport.Tracker import *
-import sqlite3
-import collections
 import numpy as np
 
 

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/FunctionalProfile.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/FunctionalProfile.py
@@ -1,7 +1,5 @@
 from CGATReport.Tracker import *
-import sqlite3
 import collections
-import numpy as np
 
 
 class AlignmentCounts(TrackerSQL):

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/GeneFinding.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/GeneFinding.py
@@ -1,9 +1,4 @@
 from CGATReport.Tracker import *
-import sqlite3
-import collections
-import numpy as np
-import glob
-import os
 
 
 class NumberOfGenes(TrackerSQL):

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/knownSpecies.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomeassembly/trackers/knownSpecies.py
@@ -1,7 +1,4 @@
 from CGATReport.Tracker import *
-import sqlite3
-import collections
-import numpy as np
 
 
 class SpeciesCount(TrackerSQL):

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomebenchmark/pipeline_metagenomebenchmark.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomebenchmark/pipeline_metagenomebenchmark.py
@@ -50,25 +50,20 @@ Code
 # load modules
 from ruffus import *
 
-import time
 import Experiment as E
-import logging as L
-import Database, CSV
 
-import sys, os, re, shutil, itertools, math, glob, time, gzip, collections, random
+import collections
+import glob
+import gzip
+import itertools
+import os
+import sys
 
-import numpy, sqlite3
-import GFF, GTF, IOTools, IndexedFasta
+import sqlite3
+import IOTools
 from rpy2.robjects import r as R
-import rpy2.robjects as ro
-import rpy2.robjects.vectors as rovectors
-from rpy2.rinterface import RRuntimeError
-import PipelineMapping
 import FastaIterator
-import PipelineMapping
-import PipelineMappingQC
 import Bed
-import Nucmer
 import pysam
 import Fastq
 import sqlite3

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomebenchmark/trackers/GenomeCoverage.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomebenchmark/trackers/GenomeCoverage.py
@@ -1,7 +1,5 @@
 from CGATReport.Tracker import *
-import sqlite3
 import collections
-import numpy as np
 
 
 # classes for returning data and plots for genome coverage analysis

--- a/CGATPipelines/pipeline_docs/pipeline_metagenomecommunities/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_metagenomecommunities/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from CGATReport import Cache
-from CGATReport import Utils
 from CGATReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Annotations.py
+++ b/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Annotations.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from IntervalReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Context.py
+++ b/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Context.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
 from IntervalReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Gat.py
+++ b/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Gat.py
@@ -1,9 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import math
 
 from IntervalReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/GeneProfile.py
+++ b/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/GeneProfile.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from IntervalReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/IntervalReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/IntervalReport.py
@@ -1,13 +1,6 @@
-import os
-import sys
-import re
-import types
-import itertools
-import glob
 
 from CGATReport.Tracker import *
 from CGATReport.Utils import PARAMS as P
-from collections import OrderedDict as odict
 
 EXPORTDIR = P.get('motifs_exportdir',
                   P.get('report_exportdir', "export"))

--- a/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Motifs.py
+++ b/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Motifs.py
@@ -1,8 +1,5 @@
 import os
-import sys
 import re
-import types
-import itertools
 import math
 import numpy
 import numpy.ma

--- a/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Nucleotide.py
+++ b/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Nucleotide.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 from IntervalReport import *
 
 import Annotations

--- a/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Peaks.py
+++ b/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/Peaks.py
@@ -1,9 +1,4 @@
 import os
-import sys
-import re
-import types
-import itertools
-import math
 
 from IntervalReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/TSS.py
+++ b/CGATPipelines/pipeline_docs/pipeline_motifs/trackers/TSS.py
@@ -1,8 +1,4 @@
 import os
-import sys
-import re
-import types
-import itertools
 import Annotations
 
 from CGATReport.Tracker import *

--- a/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Annotations.py
+++ b/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Annotations.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 import PeakcallingReport
 
-from CGATReport.Tracker import *
 from collections import OrderedDict as odict
 
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Distances.py
+++ b/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Distances.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 import PeakcallingReport
 import Annotations
 

--- a/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Intervals.py
@@ -1,6 +1,5 @@
 from PeakcallingReport import *
 
-import CGAT.IOTools
 
 
 class FoldChangeTracker(TrackerSQL):

--- a/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Intervals.py
@@ -1,7 +1,6 @@
 from PeakcallingReport import *
 
 
-
 class FoldChangeTracker(TrackerSQL):
 
     '''the fold change tracker ignores unstimulated tracks.'''

--- a/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Overlaps.py
+++ b/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Overlaps.py
@@ -1,7 +1,3 @@
-import os
-import sys
-import re
-import types
 import itertools
 import numpy
 

--- a/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Status.py
+++ b/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Status.py
@@ -1,10 +1,4 @@
-import os
-import sys
 import re
-import types
-import itertools
-import math
-import numpy
 
 from PeakcallingReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Tracks.py
+++ b/CGATPipelines/pipeline_docs/pipeline_peakcalling/trackers/Tracks.py
@@ -1,11 +1,5 @@
 '''Trackers for analysing chromatin tracks.'''
 
-import os
-import sys
-import re
-import types
-import itertools
-import glob
 from PeakcallingReport import *
 from CGATReport.Tracker import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from CGATReport import Cache
-from CGATReport import Utils
 from CGATReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/Mapping.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/Mapping.py
@@ -1,11 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 from cpgReport import *
 
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/cpgReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/cpgReport.py
@@ -1,8 +1,4 @@
-import os
-import sys
 import re
-import types
-import itertools
 import glob
 import PipelineTracks
 

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/genome_composition.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/genome_composition.py
@@ -1,13 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs.py
@@ -1,14 +1,4 @@
 import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_annotations.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_annotations.py
@@ -1,16 +1,7 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
 import numpy
 import numpy.ma
-import Stats
-import Histogram
 import cpgReport
 
-from CGATReport.Tracker import *
 from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_cgi_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_cgi_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_genomic_features.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_genomic_features.py
@@ -1,16 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 import cpgReport
 
-from CGATReport.Tracker import *
 from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_genomic_locations.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_genomic_locations.py
@@ -1,17 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 import cpgReport
 
-from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################
 

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_interval_comparison.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_interval_comparison.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_interval_lists.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_interval_lists.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_parameter_correlation.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_parameter_correlation.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_genes_with_nmi.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_genes_with_nmi.py
@@ -1,16 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 from cpgReport import *
 from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_annotations.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_annotations.py
@@ -1,13 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
 import numpy
 import numpy.ma
-import Stats
-import Histogram
 import cpgReport
 
 from CGATReport.Tracker import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_associations.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_associations.py
@@ -1,13 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 from cpgReport import *
 
 from CGATReport.Tracker import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_comparison.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_comparison.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_genomic_features.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_genomic_features.py
@@ -1,16 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 from cpgReport import *
 from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################
 

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_noncoding.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_noncoding.py
@@ -1,13 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
 import numpy
 import numpy.ma
-import Stats
-import Histogram
 from cpgReport import *
 from CGATReport.Tracker import *
 from CGATReport.odict import OrderedDict as odict

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_rnaseq_tss.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_rnaseq_tss.py
@@ -1,17 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 import cpgReport
 
-from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_tss_distance.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_interval_tss_distance.py
@@ -1,13 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
 import numpy
 import numpy.ma
-import Stats
-import Histogram
 from cpgReport import *
 from CGATReport.Tracker import *
 from CGATReport.odict import OrderedDict as odict

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_intervals_per_contig.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_intervals_per_contig.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_liver_testes_shared_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_liver_testes_shared_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_liver_testes_unique_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_liver_testes_unique_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_long_interval_capseq_profile.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_long_interval_capseq_profile.py
@@ -1,17 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
-import cpgReport
 
 from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_long_interval_chromatin_profile.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_long_interval_chromatin_profile.py
@@ -1,17 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
-import cpgReport
 
 from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_long_interval_genes.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_long_interval_genes.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
-import cpgReport
 from macs_interval_lists import *
 from CGATReport.Tracker import *
 from CGATReport.odict import OrderedDict as odict

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_overlapped_genes.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_overlapped_genes.py
@@ -1,13 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 from cpgReport import *
 from CGATReport.Tracker import *
 from CGATReport.odict import OrderedDict as odict

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_shared_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_shared_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_tissue_specific_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_tissue_specific_intervals.py
@@ -1,17 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 import cpgReport
 
-from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_unique_interval_chromatin_profile.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_unique_interval_chromatin_profile.py
@@ -1,17 +1,5 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
-import cpgReport
 
 from CGATReport.Tracker import *
-from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_unique_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_replicated_unique_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_shared_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_shared_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_tss_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_tss_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_unique_intervals.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/macs_unique_intervals.py
@@ -1,14 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import scipy.stats
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/peakshape.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/peakshape.py
@@ -1,9 +1,4 @@
 import os
-import sys
-import re
-import types
-import itertools
-import math
 import numpy
 import IOTools
 

--- a/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/predicted_cgis.py
+++ b/CGATPipelines/pipeline_docs/pipeline_proj007/trackers/predicted_cgis.py
@@ -1,17 +1,6 @@
-import os
-import sys
-import re
-import types
-import itertools
-import matplotlib.pyplot as plt
-import numpy
-import numpy.ma
-import Stats
-import Histogram
 
 from CGATReport.Tracker import *
 from cpgReport import *
-from CGATReport.odict import OrderedDict as odict
 
 ##########################################################################
 

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqdiffexpression/trackers/Isoform.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqdiffexpression/trackers/Isoform.py
@@ -1,10 +1,5 @@
-import pandas as pd
-import numpy as np
 
-from CGATReport.Tracker import SingleTableTrackerRows
-from CGATReport.Tracker import SingleTableTrackerHistogram
 from CGATReport.Tracker import *
-from CGATReport.Utils import PARAMS as P
 
 from IsoformReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqdiffexpression/trackers/Results.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqdiffexpression/trackers/Results.py
@@ -1,9 +1,4 @@
-import pandas as pd
-import numpy as np
-import sqlite3
 
-from CGATReport.Tracker import SingleTableTrackerRows
-from CGATReport.Tracker import SingleTableTrackerHistogram
 from CGATReport.Tracker import *
 from CGATReport.Utils import PARAMS as P
 

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqlncrna/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqlncrna/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from CGATReport import Cache
-from CGATReport import Utils
 from CGATReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqlncrna/trackers/CPC.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqlncrna/trackers/CPC.py
@@ -3,10 +3,8 @@ from CGATReport.Tracker import *
 import CGAT.IOTools as IOTools
 import CGAT.GTF as GTF
 import numpy as np
-import scipy.stats
 import collections
 import sqlite3
-import CGATPipelines.PipelineLncRNA as PipelineLncRNA
 from LncRNACounts import *
 
 #################################################

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqlncrna/trackers/Classification.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqlncrna/trackers/Classification.py
@@ -1,9 +1,5 @@
 from CGATReport.Tracker import *
 
-import CGAT.IOTools as IOTools
-import CGAT.GTF as GTF
-import numpy as np
-import scipy.stats
 import collections
 
 #################################################

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqlncrna/trackers/Summary.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqlncrna/trackers/Summary.py
@@ -1,10 +1,5 @@
 from CGATReport.Tracker import *
 
-import CGAT.IOTools as IOTools
-import CGAT.GTF as GTF
-import numpy as np
-import scipy.stats
-import collections
 import CGATPipelines.PipelineLncRNA as PipelineLncRNA
 
 #################################################

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqqc/trackers/RnaseqqcReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqqc/trackers/RnaseqqcReport.py
@@ -11,7 +11,6 @@ import rpy2.robjects.pandas2ri as py2ri
 from CGATReport.ResultBlock import ResultBlocks, ResultBlock
 import seaborn
 from CGATReport.Tracker import *
-from CGATReport.Utils import PARAMS as P
 from CGATReport.Utils import PARAMS
 import CGATPipelines.Pipeline as Pipeline
 import matplotlib.pyplot as plt

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Genemodels.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Genemodels.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
 from collections import OrderedDict as odict

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Lincrna.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Lincrna.py
@@ -1,7 +1,1 @@
-import os
-import sys
-import re
-import types
-import itertools
 
-from RnaseqTranscriptsReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Reference.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Reference.py
@@ -1,14 +1,10 @@
 import os
-import sys
-import re
-import types
 import itertools
 import math
 
 from RnaseqTranscriptsReport import *
 from CGATReport.ResultBlock import ResultBlock, ResultBlocks
 
-import CGAT.Stats as Stats
 
 ##########################################################################
 ##########################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Status.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Status.py
@@ -1,10 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
-import math
-import numpy
 
 from RnaseqTranscriptsReport import *
 

--- a/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Validation.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rnaseqtranscripts/trackers/Validation.py
@@ -1,8 +1,3 @@
-import os
-import sys
-import re
-import types
-import itertools
 
 from CGATReport.Tracker import *
 from RnaseqTranscriptsReport import *

--- a/CGATPipelines/pipeline_docs/pipeline_rrbs/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rrbs/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from SphinxReport import Cache
-from SphinxReport import Utils
 from SphinxReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_rrbs/trackers/rrbsReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_rrbs/trackers/rrbsReport.py
@@ -1,13 +1,7 @@
-import os
-import sys
 import re
-import types
-import itertools
-import glob
 
 from CGATReport.Tracker import *
 from CGATReport.Utils import PARAMS as P
-import CGATPipelines.PipelineTracks as PipelineTracks
 
 # get from config file
 UCSC_DATABASE = "hg19"

--- a/CGATPipelines/pipeline_docs/pipeline_scrnaseqqc/trackers/TemplateReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_scrnaseqqc/trackers/TemplateReport.py
@@ -3,7 +3,6 @@ from CGATReport.Tracker import TrackerSQL
 
 class ProjectTracker(TrackerSQL):
     '''Define convenience tracks for plots'''
-    pass
 
 
 class WordFrequencies(ProjectTracker):

--- a/CGATPipelines/pipeline_docs/pipeline_species_conservation/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_species_conservation/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from CGATReport import Cache
-from CGATReport import Utils
 from CGATReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_species_conservation/trackers/orthology.py
+++ b/CGATPipelines/pipeline_docs/pipeline_species_conservation/trackers/orthology.py
@@ -1,8 +1,4 @@
 import os
-import sys
-import re
-import types
-import itertools
 import IOTools
 from CGATReport.Tracker import *
 from CGATReport.odict import OrderedDict as odict

--- a/CGATPipelines/pipeline_docs/pipeline_splicing/__init__.py
+++ b/CGATPipelines/pipeline_docs/pipeline_splicing/__init__.py
@@ -1,2 +1,1 @@
 
-from trackers import *

--- a/CGATPipelines/pipeline_docs/pipeline_splicing/trackers/TemplateReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_splicing/trackers/TemplateReport.py
@@ -3,7 +3,6 @@ from CGATReport.Tracker import TrackerSQL
 
 class ProjectTracker(TrackerSQL):
     '''Define convenience tracks for plots'''
-    pass
 
 
 class WordFrequencies(ProjectTracker):

--- a/CGATPipelines/pipeline_docs/pipeline_template/trackers/TemplateReport.py
+++ b/CGATPipelines/pipeline_docs/pipeline_template/trackers/TemplateReport.py
@@ -1,16 +1,7 @@
-import os
-import sys
-import re
-import types
-import itertools
-import glob
 
 from CGATReport.Tracker import *
 from CGATReport.Utils import PARAMS as P
-from CGATReport.odict import OrderedDict as odict
 
-from CGATReport.ResultBlock import ResultBlock, ResultBlocks
-from CGATReport import Utils
 
 ###################################################################
 ###################################################################

--- a/CGATPipelines/pipeline_docs/pipeline_windows/server.py
+++ b/CGATPipelines/pipeline_docs/pipeline_windows/server.py
@@ -1,9 +1,8 @@
 #!/bin/env python
 
-import web, os
+import web
 
 from CGATReport import Cache
-from CGATReport import Utils
 from CGATReport import DataTree
 
 urls = ( '/data/(.*)', 'DataTable',

--- a/CGATPipelines/pipeline_docs/pipeline_windows/trackers/Status.py
+++ b/CGATPipelines/pipeline_docs/pipeline_windows/trackers/Status.py
@@ -1,10 +1,4 @@
-import os
-import sys
 import re
-import types
-import itertools
-import math
-import numpy
 
 from MedipReport import *
 

--- a/CGATPipelines/pipeline_enrichment.py
+++ b/CGATPipelines/pipeline_enrichment.py
@@ -276,7 +276,6 @@ import CGATPipelines.PipelineGSEnrichment as PipelineEnrichment
 import CGATPipelines.PipelineEnrichmentGSEA as PipelineGSEA
 import CGAT.IOTools as IOTools
 import pandas as pd
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 from textwrap import wrap

--- a/CGATPipelines/pipeline_exome.py
+++ b/CGATPipelines/pipeline_exome.py
@@ -163,13 +163,11 @@ Code
 # load modules
 from ruffus import *
 from ruffus.combinatorics import *
-from rpy2.robjects import r as R
 import sys
 import os
 import csv
 import glob
 import re
-import sqlite3
 import shutil
 import CGAT.Experiment as E
 import CGAT.IOTools as IOTools
@@ -180,7 +178,6 @@ import CGATPipelines.PipelineExome as PipelineExome
 import PipelineExomeAncestry as PipelineExomeAncestry
 import decimal
 import pandas as pd
-import numpy as np
 
 ###############################################################################
 ###############################################################################

--- a/CGATPipelines/pipeline_exome_cancer.py
+++ b/CGATPipelines/pipeline_exome_cancer.py
@@ -152,18 +152,13 @@ import numpy
 import CGAT.Experiment as E
 import sys
 import os
-import csv
 import sqlite3
 import CGAT.IOTools as IOTools
 import CGATPipelines.PipelineMapping as PipelineMapping
 import CGATPipelines.PipelineMappingQC as PipelineMappingQC
 import CGATPipelines.Pipeline as P
-import glob
-import pandas as pd
-import itertools
 import re
 import CGATPipelines.PipelineExome as PipelineExome
-import collections
 
 USECLUSTER = True
 
@@ -1187,7 +1182,6 @@ def test():
 def TestMutect():
     '''This target runs function which can be used to assess the chosen
     mutect parameters'''
-    pass
 
 
 # @follows(loadROI,

--- a/CGATPipelines/pipeline_expression.py
+++ b/CGATPipelines/pipeline_expression.py
@@ -24,8 +24,6 @@ Code
 
 """
 import sys
-import shutil
-import csv
 import re
 import glob
 import os
@@ -42,7 +40,6 @@ import CGAT.IOTools as IOTools
 import gzip
 import CGAT.Expression as Expression
 
-import rpy2
 from rpy2.robjects import r as R
 
 if os.path.exists("conf.py"):

--- a/CGATPipelines/pipeline_gwas.py
+++ b/CGATPipelines/pipeline_gwas.py
@@ -251,7 +251,6 @@ def plotPhenotypeData(infile, outfile):
     '''
 
 
-
 @follows(loadPhenotypes,
          plotPhenotypeData)
 @transform(formatPhenotypeData,

--- a/CGATPipelines/pipeline_gwas.py
+++ b/CGATPipelines/pipeline_gwas.py
@@ -250,7 +250,6 @@ def plotPhenotypeData(infile, outfile):
     for CGATReport document
     '''
 
-    pass
 
 
 @follows(loadPhenotypes,

--- a/CGATPipelines/pipeline_intervals.py
+++ b/CGATPipelines/pipeline_intervals.py
@@ -1846,7 +1846,6 @@ def annotate_intervals():
          gat)
 def full():
     '''run the full pipeline.'''
-    pass
 
 
 @follows(mkdir("report"))

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -1863,7 +1863,6 @@ for x in P.asList(PARAMS["mappers"]):
 @follows(*MAPPINGTARGETS)
 def mapping():
     ''' dummy task to define upstream mapping tasks'''
-    pass
 
 
 if "merge_pattern_input" in PARAMS and PARAMS["merge_pattern_input"]:

--- a/CGATPipelines/pipeline_mapping_benchmark.py
+++ b/CGATPipelines/pipeline_mapping_benchmark.py
@@ -306,13 +306,11 @@ def loadPicardAlignStats(infiles, outfile):
          loadPicardDuplicateStats, buildBAMStats, loadBAMStats)
 def mapReads():
     '''Align reads to target genome.'''
-    pass
 
 
 @follows(mapReads)
 def full():
     '''run the full pipeline.'''
-    pass
 
 ############################################################
 ############################################################

--- a/CGATPipelines/pipeline_metagenomecommunities.py
+++ b/CGATPipelines/pipeline_metagenomecommunities.py
@@ -171,41 +171,20 @@ Code
 from ruffus import *
 
 import CGAT.Experiment as E
-import logging as L
-import CGAT.Database as Database
-import CGAT.CSV as CSV
 
 import sys
 import os
 import re
-import shutil
-import itertools
-import math
 import glob
-import time
-import gzip
-import collections
-import random
 
-import numpy
 import sqlite3
-import CGAT.GTF as GTF
 import CGAT.IOTools as IOTools
-import CGAT.IndexedFasta as IndexedFasta
-from rpy2.robjects import r as R
-import rpy2.robjects as ro
-import rpy2.robjects.vectors as rovectors
-from rpy2.rinterface import RRuntimeError
 import CGATPipelines.PipelineMapping as PipelineMapping
 # import CGATPipelines.PipelineMetagenomeAssembly as PipelineMetagenomeAssembly
 import CGATPipelines.PipelineMetagenomeCommunities \
     as PipelineMetagenomeCommunities
-import CGAT.FastaIterator as FastaIterator
 import CGAT.Metaphlan as Metaphlan
 import CGATPipelines.PipelineMapping as PipelineMapping
-import CGATPipelines.PipelineMappingQC as PipelineMappingQC
-import pysam
-import CGAT.Fastq as Fastq
 import pandas
 # import CGATPipelines.PipelineTracks as PipelineTracks
 

--- a/CGATPipelines/pipeline_motifs.py
+++ b/CGATPipelines/pipeline_motifs.py
@@ -838,7 +838,6 @@ def exportMotifLocations(infiles, outfile):
          loadIntervals)
 def full():
     '''run the full pipeline.'''
-    pass
 
 
 @follows(mkdir("report"))

--- a/CGATPipelines/pipeline_peakcalling.py
+++ b/CGATPipelines/pipeline_peakcalling.py
@@ -243,11 +243,8 @@ from ruffus import *
 from ruffus.combinatorics import *
 import sys
 import os
-import re
-import csv
 import math
 import sqlite3
-import glob
 import shutil
 import CGAT.Experiment as E
 import CGAT.IOTools as IOTools
@@ -256,15 +253,8 @@ import CGATPipelines.PipelineMappingQC as PipelineMappingQC
 import CGATPipelines.PipelinePeakcalling as PipelinePeakcalling
 import CGAT.BamTools as Bamtools
 import CGAT.Database as DB
-import itertools
 import pandas as pd
 import numpy as np
-import rpy2
-from rpy2.robjects import r as R
-import rpy2.robjects as ro
-from rpy2.robjects import pandas2ri
-from rpy2.robjects.packages import importr
-import matplotlib
 import seaborn as sns
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
@@ -585,7 +575,6 @@ def loadPicardStats(infiles, outfile):
 def filtering():
     ''' dummy task to allow all the filtering of bams & collection of stats
     '''
-    pass
 
 
 # ### Make bigwigs of filtered bam files #####################################
@@ -712,7 +701,6 @@ else:
         '''
         Dummy task if IDR not requested.
         '''
-        pass
 
     @active_if(PARAMS['input'] != 0)
     @transform(filterInputBAMs, regex("filtered_bams.dir/(.*).bam"),
@@ -842,7 +830,6 @@ elif PARAMS['IDR_poolinputs'] == "condition" and PARAMS['IDR_run'] == 1:
         If IDR is going to be run, pooled inputs are generated above so
         they don't need to be generated again if requested.
         '''
-        pass
 
 
 @follows(makeIDRInputBams,
@@ -932,7 +919,6 @@ def preprocessing(infile, outfile):
     Dummy task to ensure all preprocessing has run and
     bam files are passed individually to the next stage.
     '''
-    pass
 
 #################################################################
 # 3) Peakcalling
@@ -1645,7 +1631,6 @@ def makeCHIPQCInputTables(infiles, outfiles):
 @follows(filtering, peakcalling, IDR)
 def full():
     ''' runs entire pipeline '''
-    pass
 
 
 ###############################################################
@@ -1771,7 +1756,6 @@ def buildNotebookIndex(outfile):
          buildNotebookIndex)
 def buildNotebooks():
     '''build notebooks'''
-    pass
 
 ##############################################################################
 

--- a/CGATPipelines/pipeline_readqc.py
+++ b/CGATPipelines/pipeline_readqc.py
@@ -169,7 +169,6 @@ def connect():
 @transform(INPUT_FORMATS, regex("(.*)"), r"\1")
 def unprocessReads(infiles, outfiles):
     """dummy task - no processing of reads."""
-    pass
 
 
 # if preprocess tools are specified, preprocessing is done on output that has
@@ -315,7 +314,6 @@ else:
     @follows(mkdir("processed.dir"))
     def processReads():
         """dummy task - no processing of reads."""
-        pass
 
 
 @active_if(PARAMS["general_reconcile"] == 1)

--- a/CGATPipelines/pipeline_rnaseqdiffexpression.py
+++ b/CGATPipelines/pipeline_rnaseqdiffexpression.py
@@ -324,31 +324,23 @@ from ruffus import *
 from ruffus.combinatorics import *
 
 import CGAT.Experiment as E
-import CGAT.Database as Database
 # import CGAT.scrum_expression as SE
 
 import sys
 import os
 import re
-import itertools
 import glob
-import numpy
 import pandas as pd
 import sqlite3
 import CGAT.GTF as GTF
 import CGAT.IOTools as IOTools
-from rpy2.robjects import r as R
-from rpy2.robjects.packages import importr
-import rpy2.robjects as ro
 
-import CGAT.BamTools as BamTools
 import CGATPipelines.PipelineGeneset as PipelineGeneset
 import CGATPipelines.PipelineRnaseq as PipelineRnaseq
 import CGATPipelines.Pipeline as P
 import CGATPipelines.PipelineTracks as PipelineTracks
 
 import CGAT.Expression as Expression
-import CGAT.Counts as Counts
 # levels of cuffdiff analysis
 # (no promotor and splice -> no lfold column)
 CUFFDIFF_LEVELS = ("gene", "cds", "isoform", "tss")
@@ -1114,7 +1106,6 @@ def loadMergedLengths(infile, outfile):
          loadMergedLengths)
 def count():
     ''' dummy task to define upstream quantification tasks'''
-    pass
 
 ###################################################
 # Differential Expression
@@ -1471,13 +1462,11 @@ for x in P.asList(PARAMS["de_tools"]):
 @follows(*DETARGETS)
 def differentialExpression():
     ''' dummy task to define upstream differential expression tasks'''
-    pass
 
 
 @follows(*NORMTARGETS)
 def NormaliseExpression():
     ''' dummy task to define upstream normalisation tasks'''
-    pass
 
 
 # AH: see below
@@ -1538,7 +1527,6 @@ def expressionSummaryPlots(infiles, logfiles):
          loadNormalisedExpression,)
 def full():
     ''' collects DE tasks and cufflinks transcript build'''
-    pass
 
 
 @follows(mkdir("report"))

--- a/CGATPipelines/pipeline_rnaseqqc.py
+++ b/CGATPipelines/pipeline_rnaseqqc.py
@@ -177,7 +177,6 @@ import pandas as pd
 import numpy as np
 import itertools
 from scipy.stats import linregress
-import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import seaborn as sns
@@ -192,7 +191,6 @@ import CGATPipelines.PipelineMapping as PipelineMapping
 import CGATPipelines.PipelineWindows as PipelineWindows
 import CGATPipelines.PipelineMappingQC as PipelineMappingQC
 import CGATPipelines.Pipeline as P
-import CGATPipelines.PipelineRnaseq as PipelineRnaseq
 
 import json
 

--- a/CGATPipelines/pipeline_rrbs.py
+++ b/CGATPipelines/pipeline_rrbs.py
@@ -139,7 +139,6 @@ import CGATPipelines.PipelineRrbs as RRBS
 import pandas as pd
 import CGATPipelines.PipelineTracks as PipelineTracks
 
-from rpy2.robjects import R
 import numpy as np
 ###################################################
 ###################################################
@@ -1088,7 +1087,6 @@ def calculateM3DSpikeClustersPvalue(infiles, outfile):
            regex("power.dir/spike_ins_subframe.tsv_(\d+)"),
            r"power.dir/spike_ins_subframe.tsv_\1_BiSeq.stats")
 def runBiSeqSpikeClusters(infile, outfile):
-    pass
     job_options = "-l mem_free=10G -pe dedicated 6"
     # RRBS.calculateBiSeqStat(infile, outfile,
     # submit=True, job_options=job_options)

--- a/CGATPipelines/pipeline_ruffus_example.py
+++ b/CGATPipelines/pipeline_ruffus_example.py
@@ -37,7 +37,6 @@ from ruffus.combinatorics import *
 import sys
 import os
 import CGATPipelines.Pipeline as P
-import shutil
 
 
 PARAMS = P.getParameters(
@@ -224,7 +223,6 @@ def basicRuffus():
     @follows because they will run automatically as the prerequisites to
     exampleSplit, exampleCollate and exampleMerge
     '''
-    pass
 
 
 @follows(mkdir("combinations"))
@@ -353,7 +351,6 @@ def advancedRuffus():
     exampleTransform and exampleSubdivide.
     exampleMerge, exampleSplit and exampleCollate will not be run.
     '''
-    pass
 
 
 @follows(basicRuffus, advancedRuffus)
@@ -364,7 +361,6 @@ def full():
     The @follows statement should ensure that all functions are covered,
     either directly or as prerequisites.
     '''
-    pass
 
 
 if __name__ == "__main__":

--- a/CGATPipelines/pipeline_scrnaseqqc.py
+++ b/CGATPipelines/pipeline_scrnaseqqc.py
@@ -67,15 +67,12 @@ Code
 """
 from ruffus import *
 from ruffus.combinatorics import *
-import re
 import sys
 import os
 import glob
-import itertools
 import sqlite3
 import CGAT.Experiment as E
 import CGATPipelines.Pipeline as P
-import CGATPipelines.PipelineTracks as PipelineTracks
 
 # load options from the config file
 PARAMS = P.getParameters(

--- a/CGATPipelines/pipeline_template_data/TemplateReport.py
+++ b/CGATPipelines/pipeline_template_data/TemplateReport.py
@@ -3,7 +3,6 @@ from CGATReport.Tracker import TrackerSQL
 
 class ProjectTracker(TrackerSQL):
     '''Define convenience tracks for plots'''
-    pass
 
 
 class WordFrequencies(ProjectTracker):

--- a/CGATPipelines/pipeline_windows.py
+++ b/CGATPipelines/pipeline_windows.py
@@ -1947,7 +1947,6 @@ def diff_windows():
     '''
     Records when all differential expression analysis is complete
     '''
-    pass
 
 
 @transform(DIFFTARGETS, suffix(".gz"), ".cpg.tsv.gz")
@@ -2466,7 +2465,6 @@ def dmr():
     '''
     Records when all DMR analysis in pipeline is complete.
     '''
-    pass
 
 
 @follows(mergeDMRWindows)
@@ -2729,7 +2727,6 @@ def buildTranscriptProfiles(infiles, outfile):
 @follows(loadTagContextOverlap, loadSummarizedContextStats)
 def context():
     """Indicates that the context_stats part of the pipeline is complete"""
-    pass
 
 
 @follows(buildTranscriptProfiles,

--- a/scripts/cgat_check_deps.py
+++ b/scripts/cgat_check_deps.py
@@ -43,7 +43,6 @@ import os
 import sys
 import re
 import ast
-import subprocess
 import CGAT.Experiment as E
 import CGAT.IOTools as IOTools
 


### PR DESCRIPTION
Used `autoflake` to automatically remove unused imports:
https://github.com/myint/autoflake

Commands:
```
autoflake --remove-all-unused-imports -i -r CGATPipelines/CGATPipelines/
autoflake --remove-all-unused-imports -i -r CGATPipelines/scripts/
```

This will help to create a (smaller) conda environment for code portability.