### PR TITLE
I have realised that if you run in quiet mode the log file does not o…

### DIFF
--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -3060,7 +3060,7 @@ class Bowtie(Mapper):
         if nfiles == 1:
             infiles = ",".join([self.quoteFile(x) for x in infiles[0]])
             statement = '''
-            %(executable)s --quiet
+            %(executable)s
             --threads %%(bowtie_threads)i
             %(data_options)s
             %(tool_options)s
@@ -3078,7 +3078,7 @@ class Bowtie(Mapper):
             infiles2 = ",".join([self.quoteFile(x) for x in infiles[1]])
 
             statement = '''
-            %(executable)s --quiet
+            %(executable)s
             --threads %%(bowtie_threads)i
             %(data_options)s
             %(tool_options)s


### PR DESCRIPTION
…utput to stderror and multiqc will not pick up this folder for reporting

If you see from the bowtie manual all of the log files are created on the stderr. If this is ran in quiet is not produced. 

see:
http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml#alignment-summary

```
Alignment summary

When Bowtie 2 finishes running, it prints messages summarizing what happened. These messages are printed to the "standard error" ("stderr") filehandle. For datasets consisting of unpaired reads, the summary might look like this:

20000 reads; of these:
  20000 (100.00%) were unpaired; of these:
    1247 (6.24%) aligned 0 times
    18739 (93.69%) aligned exactly 1 time
    14 (0.07%) aligned >1 times
93.77% overall alignment rate

```

Therefore I have removed `--quiet` from the bowtie mapping class