### PR TITLE
pbspro and disabled screen in readqc ini

### DIFF
--- a/CGATPipelines/Pipeline/Cluster.py
+++ b/CGATPipelines/Pipeline/Cluster.py
@@ -199,13 +199,14 @@ def setupDrmaaJobTemplate(drmaa_session, options, job_name, job_memory):
             spec = ["-N %s" % job_name[0:15],
                     "-l select=1:ncpus=%s:mem=%s" % (job_threads, job_memory)]
 
-        if options["cluster_options"]:
-            if "mem" not in options["cluster_options"]:
-                spec.append("%(cluster_options)s")
+            if options["cluster_options"]:
+                if "mem" not in options["cluster_options"]:
+                    spec.append("%(cluster_options)s")
 
-            elif "mem" in options["cluster_options"]:
-                raise ValueError('''mem resource specified twice, check ~/.cgat config file,
-                ini files, command line options, etc.''')
+                elif "mem" in options["cluster_options"]:
+                    raise ValueError('''mem resource specified twice, check ~/.cgat config file,
+                                        ini files, command line options, etc.
+                                     ''')
 
         if "cluster_pe_queue" in options and multithread:
             spec.append(

--- a/CGATPipelines/pipeline_readqc/pipeline.ini
+++ b/CGATPipelines/pipeline_readqc/pipeline.ini
@@ -207,7 +207,7 @@ options=
 ################################################################
 [fastq_screen]
 # only run fastq_screen if this is 1
-run=1
+run=0
 # --threads
 # --subset: subset of genome to be analysed
 options=--threads 10 --subset 100000


### PR DESCRIPTION
Hello @sebastian-luna-valero and @Acribbs ,
I installed 0.3.2 on a CentOS HPC, it runs smoothly.
Minor changes to Cluster.py for PBSPro, I think PEP8 auto changes and I messed the spacings, back to what they were for now.
I ran pipeline_readqc with --local and on the cluster:
- I disabled the screen option as the default for the ini file, errors with it asking for locations and files.
- The report build errors with a Click/Python 3 error, attached here for info. 
[make_build_report_readqc_antonio.txt](https://github.com/CGATOxford/CGATPipelines/files/1615350/make_build_report_readqc_antonio.txt)

I didn't do any thorough checks but it completes smoothly otherwise.
Thanks for all the work!
Best,
Antonio
