### PR TITLE
Copy environment to subprocess

### DIFF
--- a/CGATPipelines/Pipeline/Execution.py
+++ b/CGATPipelines/Pipeline/Execution.py
@@ -141,7 +141,8 @@ def execute(statement, **kwargs):
                                shell=True,
                                stdin=subprocess.PIPE,
                                stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
+                               stderr=subprocess.PIPE,
+                               env=os.environ.copy())
 
     # process.stdin.close()
     stdout, stderr = process.communicate()
@@ -589,7 +590,8 @@ def run(**kwargs):
                 shell=True,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+                env=os.environ.copy())
 
             # process.stdin.close()
             stdout, stderr = process.communicate()

--- a/CGATPipelines/Pipeline/Execution.py
+++ b/CGATPipelines/Pipeline/Execution.py
@@ -136,6 +136,7 @@ def execute(statement, **kwargs):
     if statement.endswith(";"):
         statement = statement[:-1]
 
+    os.environ.update({'BASH_ENV': os.path.join(os.environ['HOME'],'.bashrc')})
     process = subprocess.Popen(statement % kwargs,
                                cwd=cwd,
                                shell=True,
@@ -582,6 +583,7 @@ def run(**kwargs):
                 statement = pipes.quote(statement)
                 statement = "%s -c %s" % (shell, statement)
 
+            os.environ.update({'BASH_ENV': os.path.join(os.environ['HOME'],'.bashrc')})
             process = subprocess.Popen(
                 expandStatement(
                     statement,


### PR DESCRIPTION
If cgat is installed in a venv, the location of the "cgat" wrapper script
is added to PATH when the venv is sourced.

venvs are typically sourced in the users .bashrc.

.bashrc (and .profile) scripts are not evaluated by non-interactive shells.

The shell opened by subprocess with "shell=True" is non-interactive.

Thus, unless a copy of the "cgat" wrapper is also avaliable on some path not set in .bashrc, execution of jobs locally (i.e. non cluster) that use the cgat wrapper (e.g. cgat csv2db) will fail (cgat: command not found) for venv based installs.

This fixes the issue by copying the environment path to the subprocess
shell.